### PR TITLE
refactor: OAuthProvider table 削除

### DIFF
--- a/workspaces/server/drizzle/0009_aspiring_gunslinger.sql
+++ b/workspaces/server/drizzle/0009_aspiring_gunslinger.sql
@@ -1,0 +1,16 @@
+DROP TABLE `oauth_providers`;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_oauth_connections` (
+	`user_id` text NOT NULL,
+	`provider_id` integer NOT NULL,
+	`provider_user_id` text NOT NULL,
+	`email` text,
+	`name` text,
+	`profile_image_url` text,
+	PRIMARY KEY(`user_id`, `provider_id`)
+);
+--> statement-breakpoint
+INSERT INTO `__new_oauth_connections`("user_id", "provider_id", "provider_user_id", "email", "name", "profile_image_url") SELECT "user_id", "provider_id", "provider_user_id", "email", "name", "profile_image_url" FROM `oauth_connections`;--> statement-breakpoint
+DROP TABLE `oauth_connections`;--> statement-breakpoint
+ALTER TABLE `__new_oauth_connections` RENAME TO `oauth_connections`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/workspaces/server/drizzle/meta/0009_snapshot.json
+++ b/workspaces/server/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,721 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2fd74128-56be-478c-bbb2-e84032e19de4",
+  "prevId": "2aa11c85-849c-4d12-a333-39e3a9326989",
+  "tables": {
+    "user_profiles": {
+      "name": "user_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "real_name_kana": {
+          "name": "real_name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "academic_email": {
+          "name": "academic_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "grade_idx": {
+          "name": "grade_idx",
+          "columns": [
+            "grade"
+          ],
+          "isUnique": false
+        },
+        "display_id_unique": {
+          "name": "display_id_unique",
+          "columns": [
+            "display_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initialized_at": {
+          "name": "initialized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client_callbacks": {
+      "name": "oauth_client_callbacks",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_callbacks_client_id_oauth_clients_id_fk": {
+          "name": "oauth_client_callbacks_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_client_callbacks",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_client_callbacks_client_id_callback_url_pk": {
+          "columns": [
+            "client_id",
+            "callback_url"
+          ],
+          "name": "oauth_client_callbacks_client_id_callback_url_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client_scopes": {
+      "name": "oauth_client_scopes",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_scopes_client_id_oauth_clients_id_fk": {
+          "name": "oauth_client_scopes_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_client_scopes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_client_scopes_scope_id_oauth_scopes_id_fk": {
+          "name": "oauth_client_scopes_scope_id_oauth_scopes_id_fk",
+          "tableFrom": "oauth_client_scopes",
+          "tableTo": "oauth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_client_scopes_client_id_scope_id_pk": {
+          "columns": [
+            "client_id",
+            "scope_id"
+          ],
+          "name": "oauth_client_scopes_client_id_scope_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client_secrets": {
+      "name": "oauth_client_secrets",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issued_by": {
+          "name": "issued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_secrets_client_id_oauth_clients_id_fk": {
+          "name": "oauth_client_secrets_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_client_secrets",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_client_secrets_issued_by_users_id_fk": {
+          "name": "oauth_client_secrets_issued_by_users_id_fk",
+          "tableFrom": "oauth_client_secrets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_client_secrets_client_id_secret_pk": {
+          "columns": [
+            "client_id",
+            "secret"
+          ],
+          "name": "oauth_client_secrets_client_id_secret_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_clients_owner_id_users_id_fk": {
+          "name": "oauth_clients_owner_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_scopes": {
+      "name": "oauth_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_scopes_name_unique": {
+          "name": "oauth_scopes_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_token_scopes": {
+      "name": "oauth_token_scopes",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_token_scopes_token_id_oauth_tokens_id_fk": {
+          "name": "oauth_token_scopes_token_id_oauth_tokens_id_fk",
+          "tableFrom": "oauth_token_scopes",
+          "tableTo": "oauth_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_token_scopes_scope_id_oauth_scopes_id_fk": {
+          "name": "oauth_token_scopes_scope_id_oauth_scopes_id_fk",
+          "tableFrom": "oauth_token_scopes",
+          "tableTo": "oauth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_token_scopes_token_id_scope_id_pk": {
+          "columns": [
+            "token_id",
+            "scope_id"
+          ],
+          "name": "oauth_token_scopes_token_id_scope_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_used": {
+          "name": "code_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_tokens_code_unique": {
+          "name": "oauth_tokens_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "oauth_tokens_access_token_unique": {
+          "name": "oauth_tokens_access_token_unique",
+          "columns": [
+            "access_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_client_id_oauth_clients_id_fk": {
+          "name": "oauth_tokens_client_id_oauth_clients_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_connections": {
+      "name": "oauth_connections",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_connections_user_id_provider_id_pk": {
+          "columns": [
+            "user_id",
+            "provider_id"
+          ],
+          "name": "oauth_connections_user_id_provider_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/workspaces/server/drizzle/meta/_journal.json
+++ b/workspaces/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1736791775292,
       "tag": "0008_dapper_shotgun",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1737104816928,
+      "tag": "0009_aspiring_gunslinger",
+      "breakpoints": true
     }
   ]
 }

--- a/workspaces/server/src/db/schema/oauth/internal.ts
+++ b/workspaces/server/src/db/schema/oauth/internal.ts
@@ -4,21 +4,11 @@ import { userProfiles, users } from "../app";
 
 // 外部OAuthプロバイダを利用して IDP にログインするための、OAuth Clientとしてのスキーマ
 
-// さすがに client_secret とかは環境変数側に持たせるべき(見れちゃうので)
-// → たぶん各々の OAuth ページとかを作ることになりそう
-// OAuth の接続情報に対する Reference Provider ID として使う
-export const oauthProviders = sqliteTable("oauth_providers", {
-	id: int("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
-	name: text("name").notNull(),
-});
-
 export const oauthConnections = sqliteTable(
 	"oauth_connections",
 	{
 		userId: text("user_id").notNull(),
-		providerId: int("provider_id", { mode: "number" })
-			.notNull()
-			.references(() => oauthProviders.id),
+		providerId: int("provider_id", { mode: "number" }).notNull(),
 		providerUserId: text("provider_user_id").notNull(), // OAuth Provider 側の User ID
 		// 以下取れそうな情報を書く
 		email: text("email"),
@@ -30,20 +20,9 @@ export const oauthConnections = sqliteTable(
 	}),
 );
 
-export const oauthProvidersRelations = relations(
-	oauthProviders,
-	({ many }) => ({
-		connections: many(oauthConnections),
-	}),
-);
-
 export const oauthConnectionsRelations = relations(
 	oauthConnections,
 	({ one }) => ({
-		provider: one(oauthProviders, {
-			fields: [oauthConnections.providerId],
-			references: [oauthProviders.id],
-		}),
 		user: one(users, {
 			fields: [oauthConnections.userId],
 			references: [users.id],

--- a/workspaces/server/src/repository/oauth.ts
+++ b/workspaces/server/src/repository/oauth.ts
@@ -42,11 +42,6 @@ export type Token = {
 	accessTokenExpiresAt: Date;
 };
 
-export type OAuthProvider = {
-	id: number;
-	name: string;
-};
-
 export type OAuthConnection = {
 	userId: string;
 	providerId: number;

--- a/workspaces/server/src/routes/auth.ts
+++ b/workspaces/server/src/routes/auth.ts
@@ -10,7 +10,6 @@ const verifyRequestQuerySchema = v.object({
 	ott: v.pipe(v.string(), v.nonEmpty()),
 });
 
-// oauth flow to maximum
 const route = app
 	.route("/login", authLoginRoute)
 	.get("/verify", vValidator("query", verifyRequestQuerySchema), async (c) => {


### PR DESCRIPTION
> 動的に追加したところで、どうせServerやClient自体で増やしたロールに対して機能追加するならばコードを改修する必要がある。それならば静的なオブジェクトとして管理してあげるだけで事足りるはず。という理由ですね
>
> _Originally posted by @sor4chi in https://github.com/saitamau-maximum/id/issues/54#issuecomment-2590065913_
>

OAuth Provider もこれだなぁになったので