### PR TITLE
氏名のバリデーションチェックを追加

### DIFF
--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -4,15 +4,6 @@ const ValidateName = v.pipe(
 	v.string(),
 	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
 	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
-	v.custom(
-		(val) => typeof val === "string" && !val.startsWith(" "),
-		"先頭にスペースを使用することはできません",
-	),
-	v.custom(
-		(val) => typeof val === "string" && !val.endsWith(" "),
-		"末尾にスペースを使用することはできません",
-	),
-	v.excludes("  ", "スペースを連続して使用することはできません"),
 );
 
 export const UserSchemas = {

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -4,8 +4,9 @@ const ValidateName = v.pipe(
 	v.string(),
 	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
 	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
-	v.regex(/^(?! ).*(?<! )$/, "先頭または末尾にスペースは使用できません"),
-	v.regex(/^(?!.* {2,}).*$/, "連続するスペースは使用できません"),
+	v.startsWith(" ", "先頭にスペースを使用することはできません"),
+	v.endsWith(" ", "末尾にスペースを使用することはできません"),
+	v.includes("  "),
 );
 
 export const UserSchemas = {

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -1,9 +1,14 @@
 import * as v from "valibot";
 
+// 本名を表す文字列において、苗字、名前、ミドルネーム等が1つ以上の空文字で区切られている場合に受理される
+const realNamePattern = /^(?=.*\S(?:[\s　]+)\S).+$/;
+
 const ValidateName = v.pipe(
 	v.string(),
-	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
-	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
+	v.regex(
+		realNamePattern,
+		"苗字、名前、ミドルネーム等はスペースで区切って入力してください",
+	),
 );
 
 export const UserSchemas = {

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -1,5 +1,13 @@
 import * as v from "valibot";
 
+const validateName = v.pipe(
+	v.string(),
+	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
+	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
+	v.regex(/^(?! ).*(?<! )$/, "先頭または末尾にスペースは使用できません"),
+	v.regex(/^(?!.* {2,}).*$/, "連続するスペースは使用できません"),
+);
+
 export const UserSchemas = {
 	DisplayId: v.pipe(
 		v.string(),
@@ -17,12 +25,12 @@ export const UserSchemas = {
 		v.maxLength(16, "ユーザー名は16文字以下で入力してください"),
 	),
 	RealName: v.pipe(
-		v.string(),
+		validateName,
 		v.nonEmpty("本名を入力してください"),
 		v.maxLength(16, "本名は16文字以下で入力してください"),
 	),
 	RealNameKana: v.pipe(
-		v.string(),
+		validateName,
 		v.nonEmpty("本名(カナ)を入力してください"),
 		v.maxLength(16, "本名(カナ)は16文字以下で入力してください"),
 	),

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
 
-const validateName = v.pipe(
+const ValidateName = v.pipe(
 	v.string(),
 	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
 	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
@@ -25,12 +25,12 @@ export const UserSchemas = {
 		v.maxLength(16, "ユーザー名は16文字以下で入力してください"),
 	),
 	RealName: v.pipe(
-		validateName,
+		ValidateName,
 		v.nonEmpty("本名を入力してください"),
 		v.maxLength(16, "本名は16文字以下で入力してください"),
 	),
 	RealNameKana: v.pipe(
-		validateName,
+		ValidateName,
 		v.nonEmpty("本名(カナ)を入力してください"),
 		v.maxLength(16, "本名(カナ)は16文字以下で入力してください"),
 	),

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -4,9 +4,15 @@ const ValidateName = v.pipe(
 	v.string(),
 	v.regex(/^[\S ]+$/, "半角スペース以外の空白文字は使用できません"),
 	v.includes(" ", "苗字、名前、ミドルネーム等は半角スペースで区切ってください"),
-	v.startsWith(" ", "先頭にスペースを使用することはできません"),
-	v.endsWith(" ", "末尾にスペースを使用することはできません"),
-	v.includes("  "),
+	v.custom(
+		(val) => typeof val === "string" && !val.startsWith(" "),
+		"先頭にスペースを使用することはできません",
+	),
+	v.custom(
+		(val) => typeof val === "string" && !val.endsWith(" "),
+		"末尾にスペースを使用することはできません",
+	),
+	v.excludes("  ", "スペースを連続して使用することはできません"),
 );
 
 export const UserSchemas = {

--- a/workspaces/client/app/schema/user.ts
+++ b/workspaces/client/app/schema/user.ts
@@ -3,14 +3,6 @@ import * as v from "valibot";
 // 本名を表す文字列において、苗字、名前、ミドルネーム等が1つ以上の空文字で区切られている場合に受理される
 const realNamePattern = /^(?=.*\S(?:[\s　]+)\S).+$/;
 
-const ValidateName = v.pipe(
-	v.string(),
-	v.regex(
-		realNamePattern,
-		"苗字、名前、ミドルネーム等はスペースで区切って入力してください",
-	),
-);
-
 export const UserSchemas = {
 	DisplayId: v.pipe(
 		v.string(),
@@ -28,12 +20,20 @@ export const UserSchemas = {
 		v.maxLength(16, "ユーザー名は16文字以下で入力してください"),
 	),
 	RealName: v.pipe(
-		ValidateName,
+		v.string(),
+		v.regex(
+			realNamePattern,
+			"苗字、名前、ミドルネーム等はスペースで区切って入力してください",
+		),
 		v.nonEmpty("本名を入力してください"),
 		v.maxLength(16, "本名は16文字以下で入力してください"),
 	),
 	RealNameKana: v.pipe(
-		ValidateName,
+		v.string(),
+		v.regex(
+			realNamePattern,
+			"苗字、名前、ミドルネーム等はスペースで区切って入力してください",
+		),
 		v.nonEmpty("本名(カナ)を入力してください"),
 		v.maxLength(16, "本名(カナ)は16文字以下で入力してください"),
 	),

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -13,10 +13,12 @@ const normalizeRealName = (text: string) => {
 
 const app = factory.createApp();
 
+const ValidateName = v.pipe(v.string(), v.regex(/^[\S ]+$/), v.includes(" "));
+
 const registerSchema = v.object({
 	displayName: v.pipe(v.string(), v.nonEmpty()),
-	realName: v.pipe(v.string(), v.nonEmpty()),
-	realNameKana: v.pipe(v.string(), v.nonEmpty()),
+	realName: v.pipe(ValidateName, v.nonEmpty(), v.maxLength(16)),
+	realNameKana: v.pipe(ValidateName, v.nonEmpty(), v.maxLength(16)),
 	displayId: v.pipe(v.string(), v.nonEmpty(), v.regex(/^[a-z0-9_]{3,16}$/)),
 	email: v.pipe(v.string(), v.nonEmpty(), v.email()),
 	academicEmail: v.pipe(v.string(), v.nonEmpty(), v.email()),

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -6,6 +6,11 @@ import { OAUTH_PROVIDER_IDS } from "../constants/oauth";
 import { factory } from "../factory";
 import { authMiddleware } from "../middleware/auth";
 
+// 本名を"姓 名"の形式に正規化する
+const normalizeRealName = (text: string) => {
+	return text.trim().replace(/\s+/g, " ");
+};
+
 const app = factory.createApp();
 
 const registerSchema = v.object({
@@ -43,11 +48,15 @@ const route = app
 				grade,
 			} = c.req.valid("json");
 
+			const normalizedDisplayName = normalizeRealName(displayName);
+			const normalizedRealName = normalizeRealName(realName);
+			const normalizedRealNameKana = normalizeRealName(realNameKana);
+
 			await UserRepository.registerUser(payload.userId, {
-				displayName,
+				displayName: normalizedDisplayName,
 				displayId,
-				realName,
-				realNameKana,
+				realName: normalizedRealName,
+				realNameKana: normalizedRealNameKana,
 				academicEmail,
 				email,
 				studentId,
@@ -76,11 +85,15 @@ const route = app
 				grade,
 			} = c.req.valid("json");
 
+			const normalizedDisplayName = normalizeRealName(displayName);
+			const normalizedRealName = normalizeRealName(realName);
+			const normalizedRealNameKana = normalizeRealName(realNameKana);
+
 			await UserRepository.updateUser(payload.userId, {
-				displayName,
+				displayName: normalizedDisplayName,
 				displayId,
-				realName,
-				realNameKana,
+				realName: normalizedRealName,
+				realNameKana: normalizedRealNameKana,
 				academicEmail,
 				email,
 				studentId,

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -16,12 +16,20 @@ const normalizeRealName = (text: string) => {
 // 本名を表す文字列において、苗字、名前、ミドルネーム等が1つ以上の空文字で区切られている場合に受理される
 const realNamePattern = /^(?=.*\S(?:[\s　]+)\S).+$/;
 
-const ValidateName = v.pipe(v.string(), v.regex(realNamePattern));
-
 const registerSchema = v.object({
 	displayName: v.pipe(v.string(), v.nonEmpty()),
-	realName: v.pipe(ValidateName, v.nonEmpty(), v.maxLength(16)),
-	realNameKana: v.pipe(ValidateName, v.nonEmpty(), v.maxLength(16)),
+	realName: v.pipe(
+		v.string(),
+		v.regex(realNamePattern),
+		v.nonEmpty(),
+		v.maxLength(16),
+	),
+	realNameKana: v.pipe(
+		v.string(),
+		v.regex(realNamePattern),
+		v.nonEmpty(),
+		v.maxLength(16),
+	),
 	displayId: v.pipe(v.string(), v.nonEmpty(), v.regex(/^[a-z0-9_]{3,16}$/)),
 	email: v.pipe(v.string(), v.nonEmpty(), v.email()),
 	academicEmail: v.pipe(v.string(), v.nonEmpty(), v.email()),

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -6,14 +6,17 @@ import { OAUTH_PROVIDER_IDS } from "../constants/oauth";
 import { factory } from "../factory";
 import { authMiddleware } from "../middleware/auth";
 
+const app = factory.createApp();
+
 // 本名を"姓 名"の形式に正規化する
 const normalizeRealName = (text: string) => {
 	return text.trim().replace(/\s+/g, " ");
 };
 
-const app = factory.createApp();
+// 本名を表す文字列において、苗字、名前、ミドルネーム等が1つ以上の空文字で区切られている場合に受理される
+const realNamePattern = /^(?=.*\S(?:[\s　]+)\S).+$/;
 
-const ValidateName = v.pipe(v.string(), v.regex(/^[\S ]+$/), v.includes(" "));
+const ValidateName = v.pipe(v.string(), v.regex(realNamePattern));
 
 const registerSchema = v.object({
 	displayName: v.pipe(v.string(), v.nonEmpty()),


### PR DESCRIPTION
以下の手順で `RealName` と `RealNameKana` を処理するようにしました。

1. 半角スペースが含まれていない場合は拒否
2. 半角スペース以外の空白文字が含まれている場合は拒否
3. 半角スペースで始まったり終わる場合は拒否
4. 2つ以上連続して半角スペースがある場合は拒否
5. 文字列を受理