### PR TITLE
fix: memberMiddleware, adminMiddlewareでほぼすべてのルートを保護

### DIFF
--- a/workspaces/server/src/middleware/auth.ts
+++ b/workspaces/server/src/middleware/auth.ts
@@ -1,6 +1,8 @@
+import { every } from "hono/combine";
 import { getSignedCookie } from "hono/cookie";
 import { jwt, verify } from "hono/jwt";
 import { COOKIE_NAME } from "../constants/cookie";
+import { ROLE_IDS } from "../constants/role";
 import { factory } from "../factory";
 
 export const authMiddleware = factory.createMiddleware(async (c, next) => {
@@ -31,7 +33,7 @@ interface RoleAuthorizationMiddlewareOptions {
 	ALLOWED_ROLES: number[];
 }
 
-export const roleAuthorizationMiddleware = (
+const roleAuthorizationMiddleware = (
 	options: Partial<RoleAuthorizationMiddlewareOptions> = {},
 ) => {
 	return factory.createMiddleware(async (c, next) => {
@@ -47,3 +49,18 @@ export const roleAuthorizationMiddleware = (
 		return c.text("Forbidden", 403);
 	});
 };
+
+// adminもmemberを持っているという前提
+export const memberOnlyMiddleware = every(
+	authMiddleware,
+	roleAuthorizationMiddleware({
+		ALLOWED_ROLES: [ROLE_IDS.MEMBER],
+	}),
+);
+
+export const adminOnlyMiddleware = every(
+	authMiddleware,
+	roleAuthorizationMiddleware({
+		ALLOWED_ROLES: [ROLE_IDS.ADMIN],
+	}),
+);

--- a/workspaces/server/src/routes/admin/user.ts
+++ b/workspaces/server/src/routes/admin/user.ts
@@ -1,11 +1,8 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
-import { ROLE_BY_ID, ROLE_IDS } from "../../constants/role";
+import { ROLE_BY_ID } from "../../constants/role";
 import { factory } from "../../factory";
-import {
-	authMiddleware,
-	roleAuthorizationMiddleware,
-} from "../../middleware/auth";
+import { adminOnlyMiddleware } from "../../middleware/auth";
 
 const app = factory.createApp();
 
@@ -14,12 +11,7 @@ const UpdateRoleRequestSchema = v.object({
 });
 
 const route = app
-	.use(authMiddleware)
-	.use(
-		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.ADMIN],
-		}),
-	)
+	.use(adminOnlyMiddleware)
 	.get("/list", async (c) => {
 		const { UserRepository } = c.var;
 		try {

--- a/workspaces/server/src/routes/auth.ts
+++ b/workspaces/server/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
 import { factory } from "../factory";
-import { authMiddleware } from "../middleware/auth";
+import { memberOnlyMiddleware } from "../middleware/auth";
 import { authLoginRoute } from "./auth-login";
 
 const app = factory.createApp();
@@ -24,7 +24,7 @@ const route = app
 
 		return c.json({ jwt });
 	})
-	.get("/me", authMiddleware, async (c) => {
+	.get("/me", memberOnlyMiddleware, async (c) => {
 		const payload = c.get("jwtPayload");
 		const { UserRepository } = c.var;
 		try {

--- a/workspaces/server/src/routes/auth.ts
+++ b/workspaces/server/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import { vValidator } from "@hono/valibot-validator";
 import * as v from "valibot";
 import { factory } from "../factory";
-import { memberOnlyMiddleware } from "../middleware/auth";
+import { authMiddleware } from "../middleware/auth";
 import { authLoginRoute } from "./auth-login";
 
 const app = factory.createApp();
@@ -24,7 +24,7 @@ const route = app
 
 		return c.json({ jwt });
 	})
-	.get("/me", memberOnlyMiddleware, async (c) => {
+	.get("/me", authMiddleware, async (c) => {
 		const payload = c.get("jwtPayload");
 		const { UserRepository } = c.var;
 		try {

--- a/workspaces/server/src/routes/calendar/index.ts
+++ b/workspaces/server/src/routes/calendar/index.ts
@@ -41,7 +41,7 @@ const route = app
 				return c.text("Unauthorized", 401);
 			}
 			if (!user.roles.some((role) => role.id === ROLE_IDS.MEMBER)) {
-				return c.text("Unauthorized", 401);
+				return c.text("Forbidden", 403);
 			}
 		} catch (e) {
 			return c.text("Unauthorized", 401);

--- a/workspaces/server/src/routes/calendar/index.ts
+++ b/workspaces/server/src/routes/calendar/index.ts
@@ -2,8 +2,9 @@ import { vValidator } from "@hono/valibot-validator";
 import { sign, verify } from "hono/jwt";
 import { type EventAttributes, createEvents } from "ics";
 import * as v from "valibot";
+import { ROLE_IDS } from "../../constants/role";
 import { factory } from "../../factory";
-import { authMiddleware } from "../../middleware/auth";
+import { memberOnlyMiddleware } from "../../middleware/auth";
 import { calendarEventRoute } from "./events";
 import { calendarLocationRoute } from "./location";
 
@@ -17,7 +18,7 @@ const route = app
 	// 活動場所等が筒抜けになると怖いので、基本的には認証が必要とする
 	.route("/events", calendarEventRoute)
 	.route("/locations", calendarLocationRoute)
-	.post("/generate-url", authMiddleware, async (c) => {
+	.post("/generate-url", memberOnlyMiddleware, async (c) => {
 		const { userId } = c.get("jwtPayload");
 		// 毎回同じトークンを生成するのはあまり良くないので、ランダムな文字列を付与する
 		const randomString = Math.random().toString(36).slice(2);
@@ -27,8 +28,21 @@ const route = app
 	})
 	.get("/calendar.ics", vValidator("query", iCalParamSchema), async (c) => {
 		const { token } = c.req.valid("query");
+		const { UserRepository } = c.var;
 		try {
-			await verify(token, c.env.SECRET);
+			const payload = await verify(token, c.env.SECRET);
+			if (!payload) {
+				return c.text("Unauthorized", 401);
+			}
+			const { userId } = payload;
+			// ユーザーがメンバーであることを確認する
+			const user = await UserRepository.fetchUserProfileById(userId as string);
+			if (!user) {
+				return c.text("Unauthorized", 401);
+			}
+			if (!user.roles.some((role) => role.id === ROLE_IDS.MEMBER)) {
+				return c.text("Unauthorized", 401);
+			}
 		} catch (e) {
 			return c.text("Unauthorized", 401);
 		}

--- a/workspaces/server/src/routes/invite.ts
+++ b/workspaces/server/src/routes/invite.ts
@@ -4,12 +4,8 @@ import { cors } from "hono/cors";
 import type { CookieOptions } from "hono/utils/cookie";
 import * as v from "valibot";
 import { COOKIE_NAME } from "../constants/cookie";
-import { ROLE_IDS } from "../constants/role";
 import { factory } from "../factory";
-import {
-	authMiddleware,
-	roleAuthorizationMiddleware,
-} from "../middleware/auth";
+import { adminOnlyMiddleware } from "../middleware/auth";
 
 const app = factory.createApp();
 
@@ -53,12 +49,7 @@ const publicRoute = app
 	});
 
 const protectedRoute = app
-	.use(authMiddleware)
-	.use(
-		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.ADMIN],
-		}),
-	)
+	.use(adminOnlyMiddleware)
 	.get("/", async (c) => {
 		const { InviteRepository } = c.var;
 		try {

--- a/workspaces/server/src/routes/member.ts
+++ b/workspaces/server/src/routes/member.ts
@@ -1,12 +1,11 @@
 import { OAUTH_PROVIDER_IDS } from "../constants/oauth";
 import { factory } from "../factory";
-import { authMiddleware } from "../middleware/auth";
+import { memberOnlyMiddleware } from "../middleware/auth";
 
 const app = factory.createApp();
 
 const route = app
-	.use(authMiddleware)
-	.get("/list", async (c) => {
+	.get("/list", memberOnlyMiddleware, async (c) => {
 		const { UserRepository } = c.var;
 		try {
 			const members = await UserRepository.fetchMembers();
@@ -15,7 +14,7 @@ const route = app
 			return c.json({ error: "member not found" }, 404);
 		}
 	})
-	.get("/profile/:userDisplayId", async (c) => {
+	.get("/profile/:userDisplayId", memberOnlyMiddleware, async (c) => {
 		const userDisplayId = c.req.param("userDisplayId");
 		const { UserRepository } = c.var;
 		try {
@@ -25,7 +24,7 @@ const route = app
 			return c.json({ error: "member not found" }, 404);
 		}
 	})
-	.get("/contribution/:userDisplayId", async (c) => {
+	.get("/contribution/:userDisplayId", memberOnlyMiddleware, async (c) => {
 		const userDisplayId = c.req.param("userDisplayId");
 		const {
 			ContributionRepository,

--- a/workspaces/server/src/routes/misc.ts
+++ b/workspaces/server/src/routes/misc.ts
@@ -1,19 +1,10 @@
-import { ROLE_IDS } from "../constants/role";
 import { factory } from "../factory";
-import {
-	authMiddleware,
-	roleAuthorizationMiddleware,
-} from "../middleware/auth";
+import { memberOnlyMiddleware } from "../middleware/auth";
 
 const app = factory.createApp();
 
 const memberOnlyRoute = app
-	.use(authMiddleware)
-	.use(
-		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.MEMBER],
-		}),
-	)
+	.use(memberOnlyMiddleware)
 	.get("/discord/invitation", async (c) => {
 		if (!c.env.DISCORD_INVITATION_URL) {
 			return c.text("Discord invitation URL is not set", 500);

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -5,7 +5,7 @@ import { optimizeImage } from "wasm-image-optimization";
 import { OAUTH_PROVIDER_IDS } from "../constants/oauth";
 import { BIO_MAX_LENGTH, RESERVED_WORDS } from "../constants/validation";
 import { factory } from "../factory";
-import { authMiddleware } from "../middleware/auth";
+import { authMiddleware, memberOnlyMiddleware } from "../middleware/auth";
 
 const app = factory.createApp();
 
@@ -112,7 +112,7 @@ const route = app
 	)
 	.put(
 		"/update",
-		authMiddleware,
+		memberOnlyMiddleware,
 		vValidator("json", updateSchema),
 		async (c) => {
 			const payload = c.get("jwtPayload");
@@ -149,7 +149,7 @@ const route = app
 			return c.text("ok", 200);
 		},
 	)
-	.get("/contributions", authMiddleware, async (c) => {
+	.get("/contributions", memberOnlyMiddleware, async (c) => {
 		const payload = c.get("jwtPayload");
 		const {
 			ContributionRepository,
@@ -192,7 +192,7 @@ const route = app
 	})
 	.put(
 		"/profile-image",
-		authMiddleware,
+		memberOnlyMiddleware,
 		vValidator("form", updateProfileImageSchema),
 		async (c) => {
 			const payload = c.get("jwtPayload");


### PR DESCRIPTION
これないとユーザーが存在する招待中や退会済みのステータスでもAPIが叩けてしまう
ついでにroleAuthorizationMiddlewareを隠蔽して明示的にしてわかりやすくなった（はず）
漏れと想定外挙動ないかチェックしてほしい