### PR TITLE
各班の班長ロール作成＋班長のカレンダーの編集権限

### DIFF
--- a/workspaces/client/app/routes.ts
+++ b/workspaces/client/app/routes.ts
@@ -16,7 +16,13 @@ export default [
 				route(":userDisplayId", "routes/dashboard/members/profile/page.tsx"),
 			]),
 			...(FLAG.ENABLE_CALENDAR
-				? [route("calendar", "routes/dashboard/calendar/page.tsx")]
+				? [...prefix("calendar", [
+						layout("routes/dashboard/calendar/layout.tsx",[
+							index("routes/dashboard/calendar/page.tsx"),
+							route("edit", "routes/dashboard/calendar/edit/page.tsx"),
+						])
+					]
+				)]
 				: []),
 			route("settings", "routes/dashboard/settings/page.tsx"),
 			...prefix("admin", [

--- a/workspaces/client/app/routes.ts
+++ b/workspaces/client/app/routes.ts
@@ -16,13 +16,14 @@ export default [
 				route(":userDisplayId", "routes/dashboard/members/profile/page.tsx"),
 			]),
 			...(FLAG.ENABLE_CALENDAR
-				? [...prefix("calendar", [
-						layout("routes/dashboard/calendar/layout.tsx",[
-							index("routes/dashboard/calendar/page.tsx"),
-							route("edit", "routes/dashboard/calendar/edit/page.tsx"),
-						])
+				? [
+						...prefix("calendar", [
+							layout("routes/dashboard/calendar/layout.tsx", [
+								index("routes/dashboard/calendar/page.tsx"),
+								route("edit", "routes/dashboard/calendar/edit/page.tsx"),
+							]),
+						]),
 					]
-				)]
 				: []),
 			route("settings", "routes/dashboard/settings/page.tsx"),
 			...prefix("admin", [

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-create-event-dialog.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-create-event-dialog.tsx
@@ -1,0 +1,168 @@
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { createCallable } from "react-call";
+import { useForm } from "react-hook-form";
+import { css } from "styled-system/css";
+import * as v from "valibot";
+import { ButtonLike } from "~/components/ui/button-like";
+import { Dialog } from "~/components/ui/dialog";
+import { Form } from "~/components/ui/form";
+import { ErrorDisplay } from "~/components/ui/form/error-display";
+import { useLocations } from "~/routes/dashboard/calendar/hooks/use-locations";
+import { EVENT_DESCRIPTION_MAX_LINES, EventSchemas } from "~/schema/event";
+import type { CalendarEvent } from "~/types/event";
+import { DescriptionFormField } from "./detail-form-field";
+
+type Payload =
+	| {
+			type: "success";
+			payload: Omit<CalendarEvent, "id" | "userId">;
+	  }
+	| {
+			type: "dismiss";
+	  };
+
+const CreateFormSchema = v.object({
+	title: EventSchemas.Title,
+	description: EventSchemas.Description,
+	startAt: EventSchemas.StartAt,
+	endAt: EventSchemas.EndAt,
+	locationId: EventSchemas.LocationId,
+});
+
+type CreateFormInputValues = v.InferInput<typeof CreateFormSchema>;
+type CreateFormOutputValues = v.InferOutput<typeof CreateFormSchema>;
+
+export const CreateEventDialog = createCallable<void, Payload>(({ call }) => {
+	const { locations } = useLocations();
+
+	const {
+		handleSubmit,
+		register,
+		watch,
+		setError,
+		formState: { errors },
+	} = useForm<CreateFormInputValues, unknown, CreateFormOutputValues>({
+		resolver: valibotResolver(CreateFormSchema),
+		defaultValues: {
+			locationId: null,
+		},
+	});
+
+	const onSubmit = async (values: CreateFormOutputValues) => {
+		if (values.startAt >= values.endAt) {
+			setError("root", {
+				message: "終了日時は開始日時よりも後にしてください",
+			});
+			return;
+		}
+
+		call.end({
+			type: "success",
+			payload: {
+				...values,
+				startAt: new Date(values.startAt),
+				endAt: new Date(values.endAt),
+				locationId: values.locationId ?? undefined,
+			},
+		});
+	};
+
+	return (
+		<Dialog
+			title="イベントを作成"
+			isOpen
+			isDismissable
+			onOpenChange={(isOpen) => {
+				if (!isOpen) call.end({ type: "dismiss" });
+			}}
+		>
+			<form
+				onSubmit={handleSubmit(onSubmit)}
+				className={css({
+					display: "grid",
+					gap: 4,
+					gridTemplateColumns: "1fr",
+				})}
+			>
+				<Form.Field.TextInput
+					label="タイトル"
+					required
+					error={errors.title?.message}
+					{...register("title")}
+				/>
+
+				<DescriptionFormField
+					description={watch("description")}
+					rows={EVENT_DESCRIPTION_MAX_LINES}
+					error={errors.description?.message}
+					register={register("description")}
+					inlineOnly={true} //  イベントはインライン文法のみ
+				/>
+
+				<Form.Field.WithLabel label="開始日時" required>
+					{(id) => (
+						<>
+							<Form.Input
+								id={id}
+								required
+								type="datetime-local"
+								{...register("startAt")}
+							/>
+							<ErrorDisplay error={errors.startAt?.message} />
+						</>
+					)}
+				</Form.Field.WithLabel>
+
+				<Form.Field.WithLabel label="終了日時" required>
+					{(id) => (
+						<>
+							<Form.Input
+								id={id}
+								required
+								type="datetime-local"
+								{...register("endAt")}
+							/>
+							<ErrorDisplay error={errors.endAt?.message} />
+						</>
+					)}
+				</Form.Field.WithLabel>
+
+				<Form.FieldSet>
+					<legend>
+						<Form.LabelText>活動場所</Form.LabelText>
+					</legend>
+					<Form.RadioGroup>
+						{locations.map((location) => (
+							<Form.Radio
+								key={location.id}
+								value={location.id}
+								label={location.name}
+								{...register("locationId")}
+							/>
+						))}
+					</Form.RadioGroup>
+					<ErrorDisplay error={errors.locationId?.message} />
+				</Form.FieldSet>
+
+				<ErrorDisplay error={errors.root?.message} />
+
+				<div
+					className={css({
+						display: "flex",
+						justifyContent: "center",
+						gap: 4,
+						gridColumn: "1 / -1",
+						marginTop: 4,
+					})}
+				>
+					<button type="button" onClick={() => call.end({ type: "dismiss" })}>
+						<ButtonLike variant="secondary">キャンセル</ButtonLike>
+					</button>
+					<button type="submit">
+						<ButtonLike variant="primary">作成</ButtonLike>
+					</button>
+				</div>
+			</form>
+		</Dialog>
+	);
+});

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-create-location-dialog.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-create-location-dialog.tsx
@@ -1,0 +1,105 @@
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { createCallable } from "react-call";
+import { useForm } from "react-hook-form";
+import { css } from "styled-system/css";
+import * as v from "valibot";
+import { ButtonLike } from "~/components/ui/button-like";
+import { Dialog } from "~/components/ui/dialog";
+import { Form } from "~/components/ui/form";
+import {
+	LOCATION_DESCRIPTION_MAX_LINES,
+	LocationSchemas,
+} from "~/schema/location";
+import type { Location } from "~/types/location";
+import { DescriptionFormField } from "./detail-form-field";
+
+type Payload =
+	| {
+			type: "success";
+			payload: Omit<Location, "id" | "createdAt">;
+	  }
+	| {
+			type: "dismiss";
+	  };
+
+const CreateFormSchema = v.object({
+	name: LocationSchemas.Name,
+	description: LocationSchemas.Description,
+});
+
+type CreateFormInputValues = v.InferInput<typeof CreateFormSchema>;
+type CreateFormOutputValues = v.InferOutput<typeof CreateFormSchema>;
+
+export const CreateLocationDialog = createCallable<void, Payload>(
+	({ call }) => {
+		const {
+			handleSubmit,
+			register,
+			formState: { errors },
+			watch,
+		} = useForm<CreateFormInputValues, unknown, CreateFormOutputValues>({
+			resolver: valibotResolver(CreateFormSchema),
+		});
+
+		const onSubmit = async (values: CreateFormOutputValues) => {
+			call.end({
+				type: "success",
+				payload: {
+					...values,
+				},
+			});
+		};
+
+		return (
+			<Dialog
+				title="活動場所を作成"
+				isOpen
+				isDismissable
+				onOpenChange={(isOpen) => {
+					if (!isOpen) call.end({ type: "dismiss" });
+				}}
+			>
+				<form
+					onSubmit={handleSubmit(onSubmit)}
+					className={css({
+						display: "grid",
+						gap: 4,
+						gridTemplateColumns: "1fr",
+					})}
+				>
+					<Form.Field.TextInput
+						label="場所名"
+						required
+						error={errors.name?.message}
+						{...register("name")}
+					/>
+
+					<DescriptionFormField
+						description={watch("description")}
+						rows={LOCATION_DESCRIPTION_MAX_LINES}
+						error={errors.description?.message}
+						register={register("description")}
+						inlineOnly={false} //  活動場所は画像などを埋め込むケースがあるため、ブロック文法も許可
+					/>
+
+					<div
+						className={css({
+							display: "flex",
+							justifyContent: "center",
+							gap: 4,
+							gridColumn: "1 / -1",
+							marginTop: 4,
+						})}
+					>
+						<button type="button" onClick={() => call.end({ type: "dismiss" })}>
+							<ButtonLike variant="secondary">キャンセル</ButtonLike>
+						</button>
+						<button type="submit">
+							<ButtonLike variant="primary">作成</ButtonLike>
+						</button>
+					</div>
+				</form>
+			</Dialog>
+		);
+	},
+);

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-edit-event-dialog.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-edit-event-dialog.tsx
@@ -1,0 +1,176 @@
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { createCallable } from "react-call";
+import { useForm } from "react-hook-form";
+import { css } from "styled-system/css";
+import * as v from "valibot";
+import { ButtonLike } from "~/components/ui/button-like";
+import { Dialog } from "~/components/ui/dialog";
+import { Form } from "~/components/ui/form";
+import { ErrorDisplay } from "~/components/ui/form/error-display";
+import { useLocations } from "~/routes/dashboard/calendar/hooks/use-locations";
+import { EVENT_DESCRIPTION_MAX_LINES, EventSchemas } from "~/schema/event";
+import type { CalendarEvent } from "~/types/event";
+import { toHTMLDateTimePickerFormat } from "~/utils/date";
+import { DescriptionFormField } from "./detail-form-field";
+
+interface Props {
+	event: CalendarEvent;
+}
+
+type Payload =
+	| {
+			type: "success";
+			payload: CalendarEvent;
+	  }
+	| {
+			type: "dismiss";
+	  };
+
+const UpdateFormSchema = v.object({
+	title: EventSchemas.Title,
+	description: EventSchemas.Description,
+	startAt: EventSchemas.StartAt,
+	endAt: EventSchemas.EndAt,
+	locationId: EventSchemas.LocationId,
+});
+
+type UpdateFormInputValues = v.InferInput<typeof UpdateFormSchema>;
+type UpdateFormOutputValues = v.InferOutput<typeof UpdateFormSchema>;
+
+export const EditEventDialog = createCallable<Props, Payload>(
+	({ call, event }) => {
+		const { locations } = useLocations();
+		const {
+			handleSubmit,
+			register,
+			watch,
+			setError,
+			formState: { errors },
+		} = useForm<UpdateFormInputValues, unknown, UpdateFormOutputValues>({
+			resolver: valibotResolver(UpdateFormSchema),
+			defaultValues: {
+				title: event.title,
+				description: event.description,
+				startAt: toHTMLDateTimePickerFormat(event.startAt),
+				endAt: toHTMLDateTimePickerFormat(event.endAt),
+				locationId: event.locationId ?? null,
+			},
+		});
+
+		const onSubmit = async (values: UpdateFormOutputValues) => {
+			if (values.startAt >= values.endAt) {
+				setError("root", {
+					message: "終了日時は開始日時よりも後にしてください",
+				});
+				return;
+			}
+			const updatedEvent: CalendarEvent = {
+				...event,
+				...values,
+				startAt: values.startAt,
+				endAt: values.endAt,
+				locationId: values.locationId ?? undefined,
+			};
+			call.end({ type: "success", payload: updatedEvent });
+		};
+
+		return (
+			<Dialog
+				title="イベントを編集"
+				isOpen
+				isDismissable
+				onOpenChange={(isOpen) => {
+					if (!isOpen) call.end({ type: "dismiss" });
+				}}
+			>
+				<form
+					onSubmit={handleSubmit(onSubmit)}
+					className={css({
+						display: "grid",
+						gap: 4,
+						gridTemplateColumns: "1fr",
+					})}
+				>
+					<Form.Field.TextInput
+						label="タイトル"
+						required
+						error={errors.title?.message}
+						{...register("title")}
+					/>
+
+					<DescriptionFormField
+						description={watch("description")}
+						rows={EVENT_DESCRIPTION_MAX_LINES}
+						error={errors.description?.message}
+						register={register("description")}
+						inlineOnly={true} //  イベントはインライン文法のみ
+					/>
+
+					<Form.Field.WithLabel label="開始日時" required>
+						{(id) => (
+							<>
+								<Form.Input
+									id={id}
+									required
+									type="datetime-local"
+									{...register("startAt")}
+								/>
+								<ErrorDisplay error={errors.startAt?.message} />
+							</>
+						)}
+					</Form.Field.WithLabel>
+
+					<Form.Field.WithLabel label="終了日時" required>
+						{(id) => (
+							<>
+								<Form.Input
+									id={id}
+									required
+									type="datetime-local"
+									{...register("endAt")}
+								/>
+								<ErrorDisplay error={errors.endAt?.message} />
+							</>
+						)}
+					</Form.Field.WithLabel>
+
+					<Form.FieldSet>
+						<legend>
+							<Form.LabelText>活動場所</Form.LabelText>
+						</legend>
+						<Form.RadioGroup>
+							{locations.map((location) => (
+								<Form.Radio
+									key={location.id}
+									value={location.id}
+									label={location.name}
+									{...register("locationId")}
+								/>
+							))}
+						</Form.RadioGroup>
+						<ErrorDisplay error={errors.locationId?.message} />
+					</Form.FieldSet>
+
+					<ErrorDisplay error={errors.root?.message} />
+
+					<div
+						className={css({
+							display: "flex",
+							justifyContent: "center",
+							gap: 4,
+							gridColumn: "1 / -1",
+							marginTop: 4,
+						})}
+					>
+						<button type="button" onClick={() => call.end({ type: "dismiss" })}>
+							<ButtonLike variant="secondary">キャンセル</ButtonLike>
+						</button>
+						<button type="submit">
+							<ButtonLike variant="primary">更新</ButtonLike>
+						</button>
+					</div>
+				</form>
+			</Dialog>
+		);
+	},
+);

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-edit-location-dialog.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/callable-edit-location-dialog.tsx
@@ -1,0 +1,132 @@
+import { valibotResolver } from "@hookform/resolvers/valibot";
+import { useEffect } from "react";
+import { createCallable } from "react-call";
+import { useForm } from "react-hook-form";
+import { css } from "styled-system/css";
+import * as v from "valibot";
+import { ButtonLike } from "~/components/ui/button-like";
+import { Dialog } from "~/components/ui/dialog";
+import { Form } from "~/components/ui/form";
+import { useLocationDetail } from "~/routes/dashboard/calendar/hooks/use-location-detail";
+import {
+	LOCATION_DESCRIPTION_MAX_LINES,
+	LocationSchemas,
+} from "~/schema/location";
+import type { Location } from "~/types/location";
+import { DescriptionFormField } from "./detail-form-field";
+
+interface Props {
+	locationId: Location["id"];
+}
+
+type Payload =
+	| {
+			type: "success";
+			payload: Omit<Location, "createdAt">;
+	  }
+	| {
+			type: "dismiss";
+	  };
+
+const UpdateFormSchema = v.object({
+	name: LocationSchemas.Name,
+	description: LocationSchemas.Description,
+});
+
+type UpdateFormInputValues = v.InferInput<typeof UpdateFormSchema>;
+type UpdateFormOutputValues = v.InferOutput<typeof UpdateFormSchema>;
+
+export const EditLocationDialog = createCallable<Props, Payload>(
+	({ call, locationId }) => {
+		const { data: location, isLoading } = useLocationDetail({ locationId });
+
+		const {
+			handleSubmit,
+			register,
+			setValue,
+			watch,
+			formState: { errors },
+		} = useForm<UpdateFormInputValues, unknown, UpdateFormOutputValues>({
+			resolver: valibotResolver(UpdateFormSchema),
+			defaultValues: {
+				name: location?.name,
+				description: location?.description,
+			},
+		});
+
+		useEffect(() => {
+			if (location) {
+				setValue("name", location.name);
+				setValue("description", location.description);
+			}
+		}, [location, setValue]);
+
+		const onSubmit = async (values: UpdateFormOutputValues) => {
+			if (!location) return;
+			const updatedLocation: Location = {
+				...location,
+				...values,
+			};
+			call.end({ type: "success", payload: updatedLocation });
+		};
+
+		return (
+			<Dialog
+				title="活動場所を編集"
+				isOpen
+				isDismissable
+				onOpenChange={(isOpen) => {
+					if (!isOpen) call.end({ type: "dismiss" });
+				}}
+			>
+				{location && (
+					<form
+						onSubmit={handleSubmit(onSubmit)}
+						className={css({
+							display: "grid",
+							gap: 4,
+							gridTemplateColumns: "1fr",
+						})}
+					>
+						<Form.Field.TextInput
+							label="場所名"
+							required
+							error={errors.name?.message}
+							{...register("name")}
+						/>
+
+						<DescriptionFormField
+							description={watch("description")}
+							rows={LOCATION_DESCRIPTION_MAX_LINES}
+							error={errors.description?.message}
+							register={register("description")}
+							inlineOnly={false} //  活動場所は画像などを埋め込むケースがあるため、ブロック文法も許可
+						/>
+
+						<div
+							className={css({
+								display: "flex",
+								justifyContent: "center",
+								gap: 4,
+								gridColumn: "1 / -1",
+								marginTop: 4,
+							})}
+						>
+							<button
+								type="button"
+								onClick={() => call.end({ type: "dismiss" })}
+							>
+								<ButtonLike variant="secondary">キャンセル</ButtonLike>
+							</button>
+							<button type="submit">
+								<ButtonLike variant="primary">更新</ButtonLike>
+							</button>
+						</div>
+					</form>
+				)}
+				{!location && isLoading && "読み込み中..."}
+				{!location && !isLoading && "活動場所が見つかりませんでした"}
+			</Dialog>
+		);
+	},
+);

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/detail-form-field.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/detail-form-field.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import type { UseFormRegisterReturn } from "react-hook-form";
+import { css } from "styled-system/css";
+import { Document } from "~/components/ui/document";
+import { Form } from "~/components/ui/form";
+import { Switch } from "~/components/ui/switch";
+import { useMarkdown } from "~/hooks/use-markdown";
+
+interface Props {
+	description: string;
+	rows: number;
+	error?: string;
+	register: UseFormRegisterReturn;
+	inlineOnly: boolean;
+}
+
+interface DescriptionPreviewProps {
+	description: string;
+	inlineOnly: boolean;
+}
+
+const DescriptionPreview = ({
+	description,
+	inlineOnly,
+}: DescriptionPreviewProps) => {
+	const { reactContent } = useMarkdown(description);
+	return (
+		<div
+			className={css({
+				height: "auto",
+				maxHeight: "300px",
+				overflowY: "auto",
+				border: "1px solid",
+				borderColor: "gray.300",
+				padding: 2,
+				borderRadius: "md",
+			})}
+		>
+			<Document inlineOnly={inlineOnly}>{reactContent}</Document>
+		</div>
+	);
+};
+
+export const DescriptionFormField = ({
+	description,
+	rows,
+	error,
+	register,
+	inlineOnly,
+}: Props) => {
+	const [isDescirptionPreviewShown, setIsDescirptionPreviewShown] =
+		useState(false);
+	return (
+		<>
+			<Switch.List>
+				<Switch.Item
+					isActive={!isDescirptionPreviewShown}
+					onClick={() => setIsDescirptionPreviewShown(false)}
+				>
+					Edit
+				</Switch.Item>
+				<Switch.Item
+					isActive={isDescirptionPreviewShown}
+					onClick={() => setIsDescirptionPreviewShown(true)}
+				>
+					Preview
+				</Switch.Item>
+			</Switch.List>
+
+			{isDescirptionPreviewShown ? (
+				<DescriptionPreview description={description} inlineOnly={inlineOnly} />
+			) : (
+				<Form.Field.TextArea
+					label="説明"
+					required
+					rows={rows}
+					error={error}
+					{...register}
+				/>
+			)}
+		</>
+	);
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/events-editor.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/events-editor.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useState } from "react";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Edit,
+	Plus,
+	PlusSquare,
+	Trash,
+} from "react-feather";
+import { css } from "styled-system/css";
+import { DeleteConfirmation } from "~/components/feature/delete-confirmation";
+import { ConfirmDialog } from "~/components/logic/callable/comfirm";
+import { ButtonLike } from "~/components/ui/button-like";
+import { IconButton } from "~/components/ui/icon-button";
+import { Table } from "~/components/ui/table";
+import { useCalendar } from "~/routes/dashboard/calendar/hooks/use-calendar";
+import { useLocations } from "~/routes/dashboard/calendar/hooks/use-locations";
+import type { CalendarEvent } from "~/types/event";
+import { getFiscalYear } from "~/utils/date";
+import { useCreateEvent } from "../hooks/use-create-event";
+import { useDeleteEvent } from "../hooks/use-delete-event";
+import { useUpdateEvent } from "../hooks/use-update-event";
+import { CreateEventDialog } from "./callable-create-event-dialog";
+import { EditEventDialog } from "./callable-edit-event-dialog";
+
+const formatDuration = (startAt: Date, endAt: Date) => {
+	if (startAt.getDate() === endAt.getDate()) {
+		const startTimestamp = startAt.toLocaleTimeString("ja-JP", {
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+		const endTimestamp = endAt.toLocaleTimeString("ja-JP", {
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+		const date = startAt.toLocaleDateString("ja-JP", {
+			month: "2-digit",
+			day: "2-digit",
+			weekday: "short",
+		});
+		return `${date} ${startTimestamp} - ${endTimestamp}`;
+	}
+	return `${startAt.toLocaleDateString("ja-JP", {
+		month: "2-digit",
+		day: "2-digit",
+		weekday: "short",
+		hour: "2-digit",
+		minute: "2-digit",
+	})} - ${endAt.toLocaleDateString("ja-JP", {
+		month: "2-digit",
+		day: "2-digit",
+		weekday: "short",
+		hour: "2-digit",
+		minute: "2-digit",
+	})}`;
+};
+
+export const EventsEditor = () => {
+	const { data: events } = useCalendar();
+	// 選択中の年度
+	const [selectedFisicalYear, setSelectedFisicalYear] = useState(
+		getFiscalYear(new Date()),
+	);
+	const sortedEvents = [...events].sort(
+		(a, b) => b.startAt.getTime() - a.startAt.getTime(),
+	);
+	const { mutate: createEvent } = useCreateEvent();
+
+	const handleCreateEvent = useCallback(async () => {
+		const res = await CreateEventDialog.call();
+		if (res.type === "dismiss") return;
+		createEvent(res.payload);
+	}, [createEvent]);
+
+	const filteredEvents = sortedEvents.filter(
+		(event) =>
+			getFiscalYear(event.startAt) === selectedFisicalYear ||
+			getFiscalYear(event.endAt) === selectedFisicalYear,
+	);
+
+	return (
+		<div>
+			<div
+				className={css({
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					marginTop: 6,
+					marginBottom: 4,
+				})}
+			>
+				<div
+					className={css({
+						display: "flex",
+						gap: 2,
+						alignItems: "center",
+					})}
+				>
+					<h2
+						className={css({
+							fontSize: "xl",
+							fontWeight: "bold",
+							color: "gray.600",
+						})}
+					>
+						イベント一覧
+					</h2>
+					<div
+						className={css({ display: "flex", gap: 1, alignItems: "center" })}
+					>
+						<IconButton
+							type="button"
+							label="前の年度"
+							onClick={() => setSelectedFisicalYear(selectedFisicalYear - 1)}
+						>
+							<ChevronLeft size={16} />
+						</IconButton>
+						<span>{selectedFisicalYear}年度</span>
+						<IconButton
+							type="button"
+							label="次の年度"
+							onClick={() => setSelectedFisicalYear(selectedFisicalYear + 1)}
+						>
+							<ChevronRight size={16} />
+						</IconButton>
+					</div>
+				</div>
+				<button type="button" onClick={handleCreateEvent}>
+					<ButtonLike variant="primary" size="sm">
+						<Plus size={16} />
+						新規作成
+					</ButtonLike>
+				</button>
+			</div>
+			{filteredEvents.length === 0 ? (
+				<p
+					className={css({
+						color: "gray.500",
+						textAlign: "center",
+						marginTop: 8,
+					})}
+				>
+					イベントはありません
+				</p>
+			) : (
+				<Table.Root>
+					<thead>
+						<Table.Tr>
+							<Table.Th>タイトル</Table.Th>
+							<Table.Th>説明</Table.Th>
+							<Table.Th>期間</Table.Th>
+							<Table.Th>活動場所</Table.Th>
+							<Table.Th>操作</Table.Th>
+						</Table.Tr>
+					</thead>
+					<tbody>
+						{filteredEvents.map((event) => (
+							<EventTableRow event={event} key={event.id} />
+						))}
+					</tbody>
+				</Table.Root>
+			)}
+		</div>
+	);
+};
+
+const EventTableRow = ({ event }: { event: CalendarEvent }) => {
+	const { mutate: createEvent } = useCreateEvent();
+	const { mutate: deleteEvent } = useDeleteEvent();
+	const { mutate: updateEvent } = useUpdateEvent();
+	const { locationMap } = useLocations();
+
+	const handleDeleteEvent = useCallback(async () => {
+		const res = await ConfirmDialog.call({
+			title: "イベントの削除",
+			children: <DeleteConfirmation title={event.title} />,
+			danger: true,
+		});
+		if (res.type === "dismiss") return;
+		deleteEvent(event);
+	}, [event, deleteEvent]);
+
+	const handleEditEvent = useCallback(async () => {
+		const res = await EditEventDialog.call({ event });
+		if (res.type === "dismiss") return;
+		updateEvent(res.payload);
+	}, [event, updateEvent]);
+
+	const handleDuplicateEvent = useCallback(async () => {
+		const res = await EditEventDialog.call({ event });
+		if (res.type === "dismiss") return;
+		createEvent(res.payload);
+	}, [event, createEvent]);
+
+	const location = event.locationId ? locationMap.get(event.locationId) : null;
+
+	return (
+		<Table.Tr>
+			<Table.Td>{event.title}</Table.Td>
+			<Table.Td>
+				<div
+					className={css({
+						color: "gray.500",
+						fontSize: "sm",
+						display: "-webkit-box",
+						WebkitLineClamp: 2,
+						boxOrient: "vertical",
+						overflow: "hidden",
+					})}
+				>
+					{event.description}
+				</div>
+			</Table.Td>
+			<Table.Td>
+				<span
+					className={css({
+						color: "gray.500",
+						fontSize: "sm",
+						display: "flex",
+						justifyContent: "space-between",
+					})}
+				>
+					{formatDuration(event.startAt, event.endAt)}
+				</span>
+			</Table.Td>
+			<Table.Td>
+				{location && (
+					<p
+						className={css({
+							color: "gray.500",
+							fontSize: "sm",
+						})}
+					>
+						{location.name}
+					</p>
+				)}
+			</Table.Td>
+			<Table.Td>
+				<div className={css({ display: "flex", gap: 2, width: "fit-content" })}>
+					<IconButton label="複製" onClick={handleDuplicateEvent}>
+						<PlusSquare size={16} />
+					</IconButton>
+					/
+					<IconButton label="編集" onClick={handleEditEvent}>
+						<Edit size={16} />
+					</IconButton>
+					/
+					<IconButton label="削除" color="danger" onClick={handleDeleteEvent}>
+						<Trash size={16} />
+					</IconButton>
+				</div>
+			</Table.Td>
+		</Table.Tr>
+	);
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/location-editor.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/components/location-editor.tsx
@@ -1,0 +1,146 @@
+import { useCallback } from "react";
+import { Edit, Plus, Trash } from "react-feather";
+import { css } from "styled-system/css";
+import { DeleteConfirmation } from "~/components/feature/delete-confirmation";
+import { ConfirmDialog } from "~/components/logic/callable/comfirm";
+import { ButtonLike } from "~/components/ui/button-like";
+import { IconButton } from "~/components/ui/icon-button";
+import { Table } from "~/components/ui/table";
+import { useLocations } from "~/routes/dashboard/calendar/hooks/use-locations";
+import type { Location } from "~/types/location";
+import { useCreateLocation } from "../hooks/use-create-location";
+import { useDeleteLocation } from "../hooks/use-delete-location";
+import { useUpdateLocation } from "../hooks/use-update-location";
+import { CreateLocationDialog } from "./callable-create-location-dialog";
+import { EditLocationDialog } from "./callable-edit-location-dialog";
+
+export const LocationEditor = () => {
+	const { locations } = useLocations();
+	const { mutate: createLocation } = useCreateLocation();
+	const sortedLocation = [...locations].sort(
+		(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+	);
+
+	const handleCreateLocation = useCallback(async () => {
+		const res = await CreateLocationDialog.call();
+		if (res.type === "dismiss") return;
+		createLocation(res.payload);
+	}, [createLocation]);
+
+	return (
+		<div>
+			<div
+				className={css({
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					marginTop: 6,
+					marginBottom: 4,
+				})}
+			>
+				<div
+					className={css({
+						display: "flex",
+						gap: 2,
+						alignItems: "center",
+					})}
+				>
+					<h2
+						className={css({
+							fontSize: "xl",
+							fontWeight: "bold",
+							color: "gray.600",
+						})}
+					>
+						活動場所一覧
+					</h2>
+				</div>
+				<button type="button" onClick={handleCreateLocation}>
+					<ButtonLike variant="primary" size="sm">
+						<Plus size={16} />
+						新規作成
+					</ButtonLike>
+				</button>
+			</div>
+			{locations.length === 0 ? (
+				<p
+					className={css({
+						color: "gray.500",
+						textAlign: "center",
+						marginTop: 8,
+					})}
+				>
+					活動場所はありません
+				</p>
+			) : (
+				<Table.Root>
+					<thead>
+						<Table.Tr>
+							<Table.Th
+								className={css({
+									width: "100%",
+								})}
+							>
+								タイトル
+							</Table.Th>
+							<Table.Th>操作</Table.Th>
+						</Table.Tr>
+					</thead>
+					<tbody>
+						{sortedLocation.map((location) => (
+							<LocationTableRow location={location} key={location.id} />
+						))}
+					</tbody>
+				</Table.Root>
+			)}
+		</div>
+	);
+};
+
+interface LocationTableRowProps {
+	location: Omit<Location, "description">;
+}
+
+const LocationTableRow = ({ location }: LocationTableRowProps) => {
+	const { mutate: deleteLocation } = useDeleteLocation();
+	const { mutate: updateLocation } = useUpdateLocation();
+
+	const handleDeleteLocation = useCallback(async () => {
+		const res = await ConfirmDialog.call({
+			title: "イベントの削除",
+			children: <DeleteConfirmation title={location.name} />,
+			danger: true,
+		});
+		if (res.type === "dismiss") return;
+		deleteLocation(location);
+	}, [location, deleteLocation]);
+
+	const handleEditLocation = useCallback(async () => {
+		const res = await EditLocationDialog.call({ locationId: location.id });
+		if (res.type === "dismiss") return;
+		updateLocation(res.payload);
+	}, [location, updateLocation]);
+
+	return (
+		<Table.Tr>
+			<Table.Td>
+				<p>{location.name}</p>
+			</Table.Td>
+			<Table.Td>
+				<div className={css({ display: "flex", gap: 2, width: "fit-content" })}>
+					<IconButton label="編集" onClick={handleEditLocation}>
+						<Edit size={16} />
+					</IconButton>
+					/
+					<IconButton
+						label="削除"
+						color="danger"
+						onClick={handleDeleteLocation}
+					>
+						<Trash size={16} />
+					</IconButton>
+				</div>
+			</Table.Td>
+		</Table.Tr>
+	);
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-create-event.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-create-event.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { CalendarEvent } from "~/types/event";
+
+export const useCreateEvent = () => {
+	const { calendarRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (event: Omit<CalendarEvent, "id" | "userId">) => {
+			await calendarRepository.createEvent(event);
+			return event;
+		},
+		onSuccess: (event) => {
+			pushToast({
+				title: `イベント「${event.title}」を作成しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: calendarRepository.getAllEvents$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "イベントの作成に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-create-location.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-create-location.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { Location } from "~/types/location";
+
+export const useCreateLocation = () => {
+	const { locationRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (location: Omit<Location, "id" | "createdAt">) => {
+			await locationRepository.createLocation(location);
+			return location;
+		},
+		onSuccess: (location) => {
+			pushToast({
+				title: `活動場所「${location.name}」を作成しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: locationRepository.getAllLocations$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "活動場所の作成に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-delete-event.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-delete-event.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { CalendarEvent } from "~/types/event";
+
+export const useDeleteEvent = () => {
+	const { calendarRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (event: CalendarEvent) => {
+			await calendarRepository.deleteEvent(event.id);
+			return event;
+		},
+		onSuccess: (event) => {
+			pushToast({
+				title: `イベント「${event.title}」を削除しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: calendarRepository.getAllEvents$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "イベントの削除に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-delete-location.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-delete-location.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { Location } from "~/types/location";
+
+export const useDeleteLocation = () => {
+	const { locationRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (location: Omit<Location, "description">) => {
+			await locationRepository.deleteLocation(location.id);
+			return location;
+		},
+		onSuccess: (location) => {
+			pushToast({
+				title: `活動場所「${location.name}」を削除しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: locationRepository.getAllLocations$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "活動場所の削除に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-update-event.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-update-event.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { CalendarEvent } from "~/types/event";
+
+export const useUpdateEvent = () => {
+	const { calendarRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (event: CalendarEvent) => {
+			await calendarRepository.updateEvent(event);
+			return event;
+		},
+		onSuccess: (event) => {
+			pushToast({
+				title: `イベント「${event.title}」を更新しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: calendarRepository.getAllEvents$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "イベントの更新に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-update-location.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/internal/hooks/use-update-location.tsx
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+import type { Location } from "~/types/location";
+
+export const useUpdateLocation = () => {
+	const { locationRepository } = useRepository();
+	const queryClient = useQueryClient();
+	const { pushToast } = useToast();
+	return useMutation({
+		mutationFn: async (location: Omit<Location, "createdAt">) => {
+			await locationRepository.updateLocation(location);
+			return location;
+		},
+		onSuccess: (location) => {
+			pushToast({
+				title: `活動場所「${location.name}」を更新しました`,
+				type: "success",
+			});
+			queryClient.invalidateQueries({
+				queryKey: locationRepository.getAllLocations$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				title: "活動場所の更新に失敗しました",
+				type: "error",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/routes/dashboard/calendar/edit/page.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/page.tsx
@@ -1,0 +1,28 @@
+import { LEADER_ROLE_IDS } from "node_modules/@idp/server/dist/constants/role";
+import { CreateEventDialog } from "./internal/components/callable-create-event-dialog";
+import { CreateLocationDialog } from "./internal/components/callable-create-location-dialog";
+import { EditEventDialog } from "./internal/components/callable-edit-event-dialog";
+import { EditLocationDialog } from "./internal/components/callable-edit-location-dialog";
+import { EventsEditor } from "./internal/components/events-editor";
+import { LocationEditor } from "./internal/components/location-editor";
+import { useAuth } from "~/hooks/use-auth";
+
+
+export default function CalenderEdit() {
+	const { user, isLoading } = useAuth();
+	
+	if (isLoading || !user?.roles.some((role) => (Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id))) {
+		return null;
+	}
+	
+	return (
+		<div>
+			<EventsEditor />
+			<LocationEditor />
+			<CreateEventDialog.Root />
+			<EditEventDialog.Root />
+			<CreateLocationDialog.Root />
+			<EditLocationDialog.Root />
+		</div>
+	);
+}

--- a/workspaces/client/app/routes/dashboard/calendar/edit/page.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/edit/page.tsx
@@ -1,20 +1,24 @@
 import { LEADER_ROLE_IDS } from "node_modules/@idp/server/dist/constants/role";
+import { useAuth } from "~/hooks/use-auth";
 import { CreateEventDialog } from "./internal/components/callable-create-event-dialog";
 import { CreateLocationDialog } from "./internal/components/callable-create-location-dialog";
 import { EditEventDialog } from "./internal/components/callable-edit-event-dialog";
 import { EditLocationDialog } from "./internal/components/callable-edit-location-dialog";
 import { EventsEditor } from "./internal/components/events-editor";
 import { LocationEditor } from "./internal/components/location-editor";
-import { useAuth } from "~/hooks/use-auth";
-
 
 export default function CalenderEdit() {
 	const { user, isLoading } = useAuth();
-	
-	if (isLoading || !user?.roles.some((role) => (Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id))) {
+
+	if (
+		isLoading ||
+		!user?.roles.some((role) =>
+			(Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id),
+		)
+	) {
 		return null;
 	}
-	
+
 	return (
 		<div>
 			<EventsEditor />

--- a/workspaces/client/app/routes/dashboard/calendar/layout.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/layout.tsx
@@ -1,0 +1,60 @@
+
+import { useState, useEffect } from "react";
+import { Outlet, useNavigate } from "react-router";
+import { Tab } from "~/components/ui/tab";
+import { useAuth } from "~/hooks/use-auth";
+import { DashboardHeader } from "../internal/components/dashboard-title";
+import { LEADER_ROLE_IDS } from "node_modules/@idp/server/dist/constants/role";
+
+
+const NAVIGATION = [
+	{
+		label: "View",
+		to: "/calendar",
+		isActive: (location: string) => location === "/calendar",
+	},
+	{
+		label: "Edit",
+		to: "/calendar/edit",
+		isActive: (location: string) => location.startsWith("/calendar/edit"),
+	},
+];
+
+export default function AdminLayout() {
+	const navigate = useNavigate();
+
+	const { user, isLoading, isAuthorized } = useAuth();
+	const [isTabVisible, setIsTabVisible] = useState(false);
+
+	useEffect(() => {
+		if (isLoading || !isAuthorized) {
+			return;
+		}
+		// リーダーロールがない場合、/calendarにリダイレクト
+		if (!user?.roles.some((role) => (Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id))) {
+			setIsTabVisible(false);
+			navigate("/calendar"); // 条件を満たさない場合、/calendarにリダイレクト
+		} else {
+			setIsTabVisible(true);
+		}
+	}, [isLoading, isAuthorized, user, navigate]);
+
+	return (
+		<div>
+			<DashboardHeader
+				title="Maximum Calendar"
+				subtitle="サークルの講習会やイベントなどの予定を確認できます"
+			/>
+			{isTabVisible && (
+				<Tab.List>
+					{NAVIGATION.map((nav) => (
+						<Tab.Item key={nav.to} to={nav.to} isActive={nav.isActive}>
+							{nav.label}
+						</Tab.Item>
+					))}
+				</Tab.List>
+			)}
+			<Outlet />
+		</div>
+	);
+}

--- a/workspaces/client/app/routes/dashboard/calendar/layout.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/layout.tsx
@@ -1,11 +1,9 @@
-
-import { useState, useEffect } from "react";
+import { LEADER_ROLE_IDS } from "node_modules/@idp/server/dist/constants/role";
+import { useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
 import { Tab } from "~/components/ui/tab";
 import { useAuth } from "~/hooks/use-auth";
 import { DashboardHeader } from "../internal/components/dashboard-title";
-import { LEADER_ROLE_IDS } from "node_modules/@idp/server/dist/constants/role";
-
 
 const NAVIGATION = [
 	{
@@ -31,7 +29,11 @@ export default function AdminLayout() {
 			return;
 		}
 		// リーダーロールがない場合、/calendarにリダイレクト
-		if (!user?.roles.some((role) => (Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id))) {
+		if (
+			!user?.roles.some((role) =>
+				(Object.values(LEADER_ROLE_IDS) as number[]).includes(role.id),
+			)
+		) {
 			setIsTabVisible(false);
 			navigate("/calendar"); // 条件を満たさない場合、/calendarにリダイレクト
 		} else {

--- a/workspaces/client/app/routes/dashboard/calendar/page.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/page.tsx
@@ -6,7 +6,6 @@ import { EventList } from "~/components/feature/calendar/event-list";
 import { InformationDialog } from "~/components/logic/callable/information";
 import { ButtonLike } from "~/components/ui/button-like";
 import { useDeviceType } from "~/hooks/use-device-type";
-import { DashboardHeader } from "../internal/components/dashboard-title";
 import { ICalDisplay } from "./components/ical-display";
 import { useCalendar } from "./hooks/use-calendar";
 
@@ -58,10 +57,7 @@ export default function CalendarHome() {
 
 	return (
 		<div>
-			<DashboardHeader
-				title="Maximum Calendar"
-				subtitle="サークルの講習会やイベントなどの予定を確認できます"
-			/>
+
 			<div
 				className={css({
 					display: "flex",

--- a/workspaces/client/app/routes/dashboard/calendar/page.tsx
+++ b/workspaces/client/app/routes/dashboard/calendar/page.tsx
@@ -57,7 +57,6 @@ export default function CalendarHome() {
 
 	return (
 		<div>
-
 			<div
 				className={css({
 					display: "flex",

--- a/workspaces/server/src/constants/role.ts
+++ b/workspaces/server/src/constants/role.ts
@@ -41,20 +41,20 @@ export const TEAM_ROLE_IDS = {
 	INFRA: 208,
 } as const;
 
-export const LEADER_ROLE_IDS ={
-    /** リーダー：競技プログラミング */
+export const LEADER_ROLE_IDS = {
+	/** リーダー：競技プログラミング */
 	LEADER_CP: 302,
-    /** リーダー：Web */
+	/** リーダー：Web */
 	LEADER_WEB: 303,
-    /** リーダー：AI */
+	/** リーダー：AI */
 	LEADER_AI: 304,
-    /** リーダー：CTF */
+	/** リーダー：CTF */
 	LEADER_CTF: 305,
-    /** リーダー：モバイルアプリ */
+	/** リーダー：モバイルアプリ */
 	LEADER_MOBILE: 306,
-    /** リーダー：ゲーム開発 */
+	/** リーダー：ゲーム開発 */
 	LEADER_GAME: 307,
-    /** リーダー：インフラ */
+	/** リーダー：インフラ */
 	LEADER_INFRA: 308,
 } as const;
 

--- a/workspaces/server/src/constants/role.ts
+++ b/workspaces/server/src/constants/role.ts
@@ -41,10 +41,28 @@ export const TEAM_ROLE_IDS = {
 	INFRA: 208,
 } as const;
 
+export const LEADER_ROLE_IDS ={
+    /** リーダー：競技プログラミング */
+	LEADER_CP: 302,
+    /** リーダー：Web */
+	LEADER_WEB: 303,
+    /** リーダー：AI */
+	LEADER_AI: 304,
+    /** リーダー：CTF */
+	LEADER_CTF: 305,
+    /** リーダー：モバイルアプリ */
+	LEADER_MOBILE: 306,
+    /** リーダー：ゲーム開発 */
+	LEADER_GAME: 307,
+    /** リーダー：インフラ */
+	LEADER_INFRA: 308,
+} as const;
+
 export const ROLE_IDS = {
 	...JOB_ROLE_IDS,
 	...STATUS_ROLE_IDS,
 	...TEAM_ROLE_IDS,
+	...LEADER_ROLE_IDS,
 } as const;
 
 // もしROLE_IDSの値が重複していた場合、サーバーを起動する前にエラーを出す
@@ -126,5 +144,40 @@ export const ROLE_BY_ID: Record<number, Role> = {
 		id: ROLE_IDS.DEV,
 		name: "開発",
 		color: "#0000FF",
+	},
+	[ROLE_IDS.LEADER_CP]: {
+		id: ROLE_IDS.LEADER_CP,
+		name: "班長：競プロ",
+		color: "#C8AA00",
+	},
+	[ROLE_IDS.LEADER_WEB]: {
+		id: ROLE_IDS.LEADER_WEB,
+		name: "班長：Web",
+		color: "#FF1493",
+	},
+	[ROLE_IDS.LEADER_AI]: {
+		id: ROLE_IDS.LEADER_AI,
+		name: "班長：広義AI",
+		color: "#00BFFF",
+	},
+	[ROLE_IDS.LEADER_CTF]: {
+		id: ROLE_IDS.LEADER_CTF,
+		name: "班長：CTF",
+		color: "#800080",
+	},
+	[ROLE_IDS.LEADER_MOBILE]: {
+		id: ROLE_IDS.LEADER_MOBILE,
+		name: "班長：モバイルアプリ",
+		color: "#1F0084",
+	},
+	[ROLE_IDS.LEADER_GAME]: {
+		id: ROLE_IDS.LEADER_GAME,
+		name: "班長：ゲーム開発",
+		color: "#FF69B4",
+	},
+	[ROLE_IDS.LEADER_INFRA]: {
+		id: ROLE_IDS.LEADER_INFRA,
+		name: "班長：インフラ",
+		color: "#008000",
 	},
 };

--- a/workspaces/server/src/middleware/auth.ts
+++ b/workspaces/server/src/middleware/auth.ts
@@ -68,6 +68,9 @@ export const adminOnlyMiddleware = every(
 export const adminAndLeaderOnlyMiddleware = every(
 	authMiddleware,
 	roleAuthorizationMiddleware({
-		ALLOWED_ROLES: [ROLE_IDS.ADMIN, ...(Object.values(LEADER_ROLE_IDS) as number[])],
+		ALLOWED_ROLES: [
+			ROLE_IDS.ADMIN,
+			...(Object.values(LEADER_ROLE_IDS) as number[]),
+		],
 	}),
 );

--- a/workspaces/server/src/middleware/auth.ts
+++ b/workspaces/server/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { every } from "hono/combine";
 import { getSignedCookie } from "hono/cookie";
 import { jwt, verify } from "hono/jwt";
 import { COOKIE_NAME } from "../constants/cookie";
-import { ROLE_IDS } from "../constants/role";
+import { LEADER_ROLE_IDS, ROLE_IDS } from "../constants/role";
 import { factory } from "../factory";
 
 export const authMiddleware = factory.createMiddleware(async (c, next) => {
@@ -62,5 +62,12 @@ export const adminOnlyMiddleware = every(
 	authMiddleware,
 	roleAuthorizationMiddleware({
 		ALLOWED_ROLES: [ROLE_IDS.ADMIN],
+	}),
+);
+
+export const adminAndLeaderOnlyMiddleware = every(
+	authMiddleware,
+	roleAuthorizationMiddleware({
+		ALLOWED_ROLES: [ROLE_IDS.ADMIN, ...(Object.values(LEADER_ROLE_IDS) as number[])],
 	}),
 );

--- a/workspaces/server/src/routes/calendar/events.ts
+++ b/workspaces/server/src/routes/calendar/events.ts
@@ -3,7 +3,7 @@ import { validator } from "hono/validator";
 import * as v from "valibot";
 import { factory } from "../../factory";
 import {
-	adminOnlyMiddleware,
+	adminAndLeaderOnlyMiddleware,
 	memberOnlyMiddleware,
 } from "../../middleware/auth";
 
@@ -38,7 +38,7 @@ const route = app
 	})
 	.post(
 		"/",
-		adminOnlyMiddleware,
+		adminAndLeaderOnlyMiddleware,
 		vValidator("json", createEventSchema),
 		validator("json", (value, c) => {
 			if (new Date(value.startAt) >= new Date(value.endAt)) {
@@ -69,7 +69,7 @@ const route = app
 	)
 	.put(
 		"/:id",
-		adminOnlyMiddleware,
+		adminAndLeaderOnlyMiddleware,
 		vValidator("json", updateEventSchema),
 		validator("json", (value, c) => {
 			if (new Date(value.startAt) >= new Date(value.endAt)) {
@@ -99,7 +99,7 @@ const route = app
 			}
 		},
 	)
-	.delete("/:id", adminOnlyMiddleware, async (c) => {
+	.delete("/:id", adminAndLeaderOnlyMiddleware, async (c) => {
 		const { CalendarRepository } = c.var;
 		const id = c.req.param("id");
 		try {

--- a/workspaces/server/src/routes/calendar/events.ts
+++ b/workspaces/server/src/routes/calendar/events.ts
@@ -1,7 +1,7 @@
 import { vValidator } from "@hono/valibot-validator";
 import { validator } from "hono/validator";
 import * as v from "valibot";
-import { ROLE_IDS } from "../../constants/role";
+import { ROLE_IDS, LEADER_ROLE_IDS } from "../../constants/role";
 import { factory } from "../../factory";
 import {
 	authMiddleware,
@@ -41,7 +41,7 @@ const route = app
 	.post(
 		"/",
 		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.ADMIN],
+			ALLOWED_ROLES: [ROLE_IDS.ADMIN, ...Object.values(LEADER_ROLE_IDS)],
 		}),
 		vValidator("json", createEventSchema),
 		validator("json", (value, c) => {
@@ -74,7 +74,7 @@ const route = app
 	.put(
 		"/:id",
 		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.ADMIN],
+			ALLOWED_ROLES: [ROLE_IDS.ADMIN, ...(Object.values(LEADER_ROLE_IDS) as number[])],
 		}),
 		vValidator("json", updateEventSchema),
 		validator("json", (value, c) => {
@@ -108,7 +108,7 @@ const route = app
 	.delete(
 		"/:id",
 		roleAuthorizationMiddleware({
-			ALLOWED_ROLES: [ROLE_IDS.ADMIN],
+			ALLOWED_ROLES: [ROLE_IDS.ADMIN, ...Object.values(LEADER_ROLE_IDS)],
 		}),
 		async (c) => {
 			const { CalendarRepository } = c.var;


### PR DESCRIPTION
- 各班の班長ロールを作りました。
「カレンダー編集ロール」等だと、あまりに局所的すぎるかと思いこの形にしました。
- カレンダーページに班長だけがアクセスできる編集ページを追加しました。
見た目、機能自体はadminページのものと同一です
- serverのミドルウェアにadmin+leader onlyのミドルウェアを追加し、eventに対する操作に適用しました。