### PR TITLE
fix(seed): `newRoleIds` がない場合のエラー回避

### DIFF
--- a/workspaces/server/src/db/seed/senario/edit-user-role.ts
+++ b/workspaces/server/src/db/seed/senario/edit-user-role.ts
@@ -42,12 +42,14 @@ export const editUserRole = async (
 		(roleId) => !roleIds.includes(roleId),
 	);
 
-	await client.insert(schema.userRoles).values(
-		newRoleIds.map((roleId) => ({
-			userId: user.userId,
-			roleId,
-		})),
-	);
+	if (newRoleIds.length > 0) {
+		await client.insert(schema.userRoles).values(
+			newRoleIds.map((roleId) => ({
+				userId: user.userId,
+				roleId,
+			})),
+		);
+	}
 
 	await client
 		.delete(schema.userRoles)


### PR DESCRIPTION
`Error: values() must be called with at least one value` を修正
