### PR TITLE
fix: プロフィール更新時にInternal Server Errorと返ってくる問題を修正

### DIFF
--- a/workspaces/server/src/infrastructure/repository/cloudflare/user.ts
+++ b/workspaces/server/src/infrastructure/repository/cloudflare/user.ts
@@ -230,12 +230,14 @@ export class CloudflareUserRepository implements IUserRepository {
 					.delete(schema.socialLinks)
 					.where(eq(schema.socialLinks.userId, userId));
 
-				await this.client.insert(schema.socialLinks).values(
-					payload.socialLinks.map((link) => ({
-						userId,
-						url: link,
-					})),
-				);
+				if (payload.socialLinks.length > 0) {
+					await this.client.insert(schema.socialLinks).values(
+						payload.socialLinks.map((link) => ({
+							userId,
+							url: link,
+						})),
+					);
+				}
 			}
 		} catch (err) {
 			throw new Error("Failed to update user");


### PR DESCRIPTION
close #221
ソーシャルリンクが空の状態で更新しようとすると`Error: values() must be called with at least one value`とエラーがでていたので修正しました