### PR TITLE
fix: ユーザーボックス内のユーザー名を一行にし、文字数によりフォントサイズを変更

### DIFF
--- a/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
+++ b/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
@@ -317,7 +317,7 @@ export const Sidebar = () => {
 										textOverflow: "ellipsis",
 										maxWidth: "160px",
 										fontSize: [
-											(user.displayName?.length ?? 0) < 10  ? "lg" : "md",
+											(user.displayName?.length ?? 0) < 10 ? "lg" : "md",
 										],
 									})}
 									title={user.displayName}

--- a/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
+++ b/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
@@ -316,9 +316,7 @@ export const Sidebar = () => {
 										overflow: "hidden",
 										textOverflow: "ellipsis",
 										maxWidth: "160px",
-										fontSize: [
-											(user.displayName?.length ?? 0) < 10 ? "lg" : "md",
-										],
+										fontSize: "md",
 									})}
 									title={user.displayName}
 								>

--- a/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
+++ b/workspaces/client/app/routes/dashboard/internal/components/sidebar.tsx
@@ -311,9 +311,16 @@ export const Sidebar = () => {
 							>
 								<p
 									className={css({
-										fontSize: "lg",
 										fontWeight: 500,
+										whiteSpace: "nowrap",
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										maxWidth: "160px",
+										fontSize: [
+											(user.displayName?.length ?? 0) < 10  ? "lg" : "md",
+										],
 									})}
+									title={user.displayName}
 								>
 									{user.displayName}
 								</p>


### PR DESCRIPTION
<img width="1920" height="1032" alt="スクリーンショット 2025-08-14 064827" src="https://github.com/user-attachments/assets/231861c5-db14-47ff-b56e-feb3470bdb3b" />
10文字未満
<img width="1920" height="1032" alt="スクリーンショット 2025-08-14 064840" src="https://github.com/user-attachments/assets/0c9a3214-3232-44b2-96ed-44555de49e52" />
10文字以上
<img width="1920" height="1032" alt="スクリーンショット 2025-08-14 064909" src="https://github.com/user-attachments/assets/d960549b-2c77-49b5-b786-1c54930897ff" />
長すぎたら"…"にしました(Twitter方式)
