### PR TITLE
fix: OAuth Token Endpoint に Authorization ヘッダを使う

### DIFF
--- a/workspaces/server/src/routes/dev.ts
+++ b/workspaces/server/src/routes/dev.ts
@@ -46,8 +46,6 @@ const route = app
 		const body = new FormData();
 		body.append("grant_type", "authorization_code");
 		body.append("code", code);
-		body.append("client_id", clientId);
-		body.append("client_secret", clientSecret);
 		body.append(
 			"redirect_uri",
 			`${url.origin}/dev/oauth/${clientId}/${clientSecret}/callback`,
@@ -56,6 +54,9 @@ const route = app
 		const res = await fetch(`${url.origin}/oauth/access-token`, {
 			method: "POST",
 			body,
+			headers: {
+				Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`, // client_id と client_secret は Basic 認証で送る
+			},
 		});
 		c.header("Cache-Control", "no-store");
 		c.header("Pragma", "no-cache");

--- a/workspaces/server/src/routes/oauth/accessToken.ts
+++ b/workspaces/server/src/routes/oauth/accessToken.ts
@@ -17,8 +17,8 @@ const requestBodySchema = v.object({
 	grant_type: v.pipe(v.string(), v.nonEmpty()),
 	code: v.pipe(v.string(), v.nonEmpty()),
 	redirect_uri: v.optional(v.pipe(v.string(), v.nonEmpty(), v.url())),
-	client_id: v.pipe(v.string(), v.nonEmpty()),
-	client_secret: v.pipe(v.string(), v.nonEmpty()),
+	client_id: v.optional(v.pipe(v.string(), v.nonEmpty())),
+	client_secret: v.optional(v.pipe(v.string(), v.nonEmpty())),
 });
 
 const app = factory.createApp();
@@ -29,21 +29,6 @@ const OAUTH_ERROR_URI =
 const route = app
 	.post(
 		"/",
-		async (c, next) => {
-			// もし Authorization ヘッダーがある場合は 401 を返す
-			const authHeader = c.req.header("Authorization");
-			if (authHeader) {
-				return c.json(
-					{
-						error: "invalid_request",
-						error_description: "Authorization header is not allowed",
-						error_uri: OAUTH_ERROR_URI,
-					},
-					401,
-				);
-			}
-			return next();
-		},
 		vValidator("form", requestBodySchema, async (res, c) => {
 			if (!res.success)
 				return c.json(
@@ -56,8 +41,49 @@ const route = app
 				);
 		}),
 		async (c) => {
-			const { client_id, client_secret, code, grant_type, redirect_uri } =
-				c.req.valid("form");
+			const { code, grant_type, redirect_uri } = c.req.valid("form");
+
+			const { client_id, client_secret, errorRes } = (() => {
+				const { client_id, client_secret } = c.req.valid("form");
+				// もし POST body に client_id, client_secret があればそれを使う
+				if (client_id && client_secret) return { client_id, client_secret };
+
+				// Authorization ヘッダをチェック
+				const authHeader = c.req.header("Authorization");
+				if (!authHeader || !authHeader.startsWith("Basic ")) {
+					return {
+						errorRes: c.json(
+							{
+								error: "invalid_request",
+								error_description: "Missing client_id or client_secret",
+								error_uri: OAUTH_ERROR_URI,
+							},
+							401,
+						),
+					};
+				}
+
+				const base64Credentials = authHeader.slice(6); // "Basic " を除去
+				const [clientId, clientSecret, ...rest] = atob(base64Credentials)
+					.split(":")
+					.map((s) => s.trim());
+				if (rest.length > 0 || !clientId || !clientSecret) {
+					// ":" が複数あった場合
+					return {
+						errorRes: c.json(
+							{
+								error: "invalid_request",
+								error_description: "Invalid Authorization header format",
+								error_uri: OAUTH_ERROR_URI,
+							},
+							400,
+						),
+					};
+				}
+
+				return { client_id: clientId, client_secret: clientSecret };
+			})();
+			if (errorRes) return errorRes;
 
 			const nowUnixMs = Date.now();
 


### PR DESCRIPTION
> The authorization server MUST support the HTTP Basic authentication scheme for authenticating clients that were issued a client password.
> Including the client credentials in the request-body using the two parameters is NOT RECOMMENDED and SHOULD be limited to clients unable to directly utilize the HTTP Basic authentication scheme (or other password-based HTTP authentication schemes).
> _https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1_

「HTTP Basic Authentication をサポートしろ、 Request Body に含むのは非推奨」らしいです
完全に誤解してました