### PR TITLE
feat: ID Token の claims に roles を追加

### DIFF
--- a/workspaces/schema/src/entity/oauth-external/oidc-userinfo.ts
+++ b/workspaces/schema/src/entity/oauth-external/oidc-userinfo.ts
@@ -28,6 +28,11 @@ export const OIDCEmail = v.object({
 });
 export type OIDCEmail = v.InferOutput<typeof OIDCEmail>;
 
+export const OIDCRoles = v.object({
+	roles: v.array(v.string()),
+});
+export type OIDCRoles = v.InferOutput<typeof OIDCRoles>;
+
 // まだ持ってない
 // export const OIDCPhone = v.object({
 // 	phone_number: v.pipe(v.string(), v.nonEmpty()),
@@ -51,5 +56,6 @@ export const OIDCUserInfo = v.intersect([
 	OIDCBasicUserInfo,
 	v.partial(OIDCProfile),
 	v.partial(OIDCEmail),
+	v.partial(OIDCRoles),
 ]);
 export type OIDCUserInfo = v.InferOutput<typeof OIDCUserInfo>;

--- a/workspaces/schema/src/entity/oauth-external/scope.ts
+++ b/workspaces/schema/src/entity/oauth-external/scope.ts
@@ -2,7 +2,6 @@ import * as v from "valibot";
 
 export const SCOPE_IDS = {
 	READ_BASIC_INFO: 1,
-	READ_ROLES: 2,
 
 	// OpenID 系
 	OPENID: 1000,
@@ -11,6 +10,7 @@ export const SCOPE_IDS = {
 	// 必要情報を持っていないので実装しないが、一応予約済みとしてコメントアウト
 	// ADDRESS: 1003,
 	// PHONE: 1004,
+	READ_ROLES: 1005,
 } as const;
 
 // もしSCOPE_IDSの値が重複していた場合、サーバーを起動する前にエラーを出す

--- a/workspaces/schema/src/entity/oauth-external/scope.ts
+++ b/workspaces/schema/src/entity/oauth-external/scope.ts
@@ -2,6 +2,7 @@ import * as v from "valibot";
 
 export const SCOPE_IDS = {
 	READ_BASIC_INFO: 1,
+	READ_ROLES: 2,
 
 	// OpenID 系
 	OPENID: 1000,
@@ -54,6 +55,11 @@ export const SCOPES_BY_ID = {
 		name: "email",
 		description:
 			"このサービスが、Maximum IdP に登録されている「連絡の取れるメールアドレス」を取得することを許可します。",
+	},
+	[SCOPE_IDS.READ_ROLES]: {
+		id: SCOPE_IDS.READ_ROLES,
+		name: "read:roles",
+		description: "このサービスがあなたのロール情報を読み取ることを許可します。",
 	},
 	// [SCOPE_IDS.ADDRESS]: {
 	// 	id: SCOPE_IDS.ADDRESS,

--- a/workspaces/schema/src/entity/oauth-external/scope.ts
+++ b/workspaces/schema/src/entity/oauth-external/scope.ts
@@ -2,6 +2,8 @@ import * as v from "valibot";
 
 export const SCOPE_IDS = {
 	READ_BASIC_INFO: 1,
+	// write:basic_infoやadmin:basic_infoなどを追加する可能性があるので、2 ~ 5は空けておく
+	READ_ROLES: 6,
 
 	// OpenID 系
 	OPENID: 1000,
@@ -10,7 +12,6 @@ export const SCOPE_IDS = {
 	// 必要情報を持っていないので実装しないが、一応予約済みとしてコメントアウト
 	// ADDRESS: 1003,
 	// PHONE: 1004,
-	READ_ROLES: 1005,
 } as const;
 
 // もしSCOPE_IDSの値が重複していた場合、サーバーを起動する前にエラーを出す

--- a/workspaces/server/src/routes/oauth/access-token.ts
+++ b/workspaces/server/src/routes/oauth/access-token.ts
@@ -204,6 +204,7 @@ const route = app
 								email: userInfo.email,
 							}
 						: {}),
+					roles: userInfo.roles.map((r) => r.slug),
 				});
 			}
 

--- a/workspaces/server/src/routes/oauth/access-token.ts
+++ b/workspaces/server/src/routes/oauth/access-token.ts
@@ -204,7 +204,11 @@ const route = app
 								email: userInfo.email,
 							}
 						: {}),
-					roles: userInfo.roles.map((r) => r.slug),
+					...(tokenInfo.scopes.find((s) => s.id === SCOPE_IDS.READ_ROLES)
+						? {
+								roles: userInfo.roles.map((r) => r.slug),
+							}
+						: {}),
 				});
 			}
 

--- a/workspaces/server/src/routes/oauth/callback.ts
+++ b/workspaces/server/src/routes/oauth/callback.ts
@@ -176,6 +176,8 @@ const route = app
 									email: userInfo.email,
 								}
 							: {}),
+						// Custom Claim
+						roles: userInfo.roles.map((r) => r.slug),
 					});
 
 					res.append("id_token", id_token);

--- a/workspaces/server/src/routes/oauth/callback.ts
+++ b/workspaces/server/src/routes/oauth/callback.ts
@@ -176,8 +176,12 @@ const route = app
 									email: userInfo.email,
 								}
 							: {}),
-						// Custom Claim
-						roles: userInfo.roles.map((r) => r.slug),
+						// Custom Claims
+						...(scopes.find((s) => s.id === SCOPE_IDS.READ_ROLES)
+							? {
+									roles: userInfo.roles.map((r) => r.slug),
+								}
+							: {}),
 					});
 
 					res.append("id_token", id_token);

--- a/workspaces/server/src/routes/oauth/resources.ts
+++ b/workspaces/server/src/routes/oauth/resources.ts
@@ -96,6 +96,9 @@ const route = app
 				userInfo.email_verified = false; // メールアドレス検証はしていないので false 固定
 			}
 		}
+		if (tokenInfo.scopes.some((scope) => scope.id === SCOPE_IDS.READ_ROLES)) {
+			userInfo.roles = tokenInfo.user.roles.map((role) => role.slug);
+		}
 
 		return c.json<OIDCUserInfo>(userInfo);
 	});

--- a/workspaces/server/src/utils/oauth/oidc-logic.ts
+++ b/workspaces/server/src/utils/oauth/oidc-logic.ts
@@ -9,7 +9,7 @@ type OidcIdTokenClaims = Pick<
 >;
 
 type OidcIdTokenCustomClaims = {
-	roles: string[];
+	roles?: string[];
 };
 
 interface OidcIdTokenPayloadBase {

--- a/workspaces/server/src/utils/oauth/oidc-logic.ts
+++ b/workspaces/server/src/utils/oauth/oidc-logic.ts
@@ -5,12 +5,8 @@ import { importKey, sign } from "./key";
 
 type OidcIdTokenClaims = Pick<
 	OIDCUserInfo,
-	"name" | "nickname" | "preferred_username" | "picture" | "email"
+	"name" | "nickname" | "preferred_username" | "picture" | "email" | "roles"
 >;
-
-type OidcIdTokenCustomClaims = {
-	roles?: string[];
-};
 
 interface OidcIdTokenPayloadBase {
 	iss: string;
@@ -23,9 +19,7 @@ interface OidcIdTokenPayloadBase {
 	// acr, amr, azp は使わないので省略
 	at_hash: string;
 }
-type OidcIdTokenPayload = OidcIdTokenPayloadBase &
-	OidcIdTokenClaims &
-	OidcIdTokenCustomClaims;
+type OidcIdTokenPayload = OidcIdTokenPayloadBase & OidcIdTokenClaims;
 
 interface ParamBase {
 	clientId: string;
@@ -36,7 +30,7 @@ interface ParamBase {
 	accessToken: string;
 	privateKey: string;
 }
-type Param = ParamBase & OidcIdTokenClaims & OidcIdTokenCustomClaims;
+type Param = ParamBase & OidcIdTokenClaims;
 
 const signJWT = async (
 	payload: OidcIdTokenPayload,

--- a/workspaces/server/src/utils/oauth/oidc-logic.ts
+++ b/workspaces/server/src/utils/oauth/oidc-logic.ts
@@ -8,6 +8,10 @@ type OidcIdTokenClaims = Pick<
 	"name" | "nickname" | "preferred_username" | "picture" | "email"
 >;
 
+type OidcIdTokenCustomClaims = {
+	roles: string[];
+};
+
 interface OidcIdTokenPayloadBase {
 	iss: string;
 	sub: string;
@@ -19,7 +23,9 @@ interface OidcIdTokenPayloadBase {
 	// acr, amr, azp は使わないので省略
 	at_hash: string;
 }
-type OidcIdTokenPayload = OidcIdTokenPayloadBase & OidcIdTokenClaims;
+type OidcIdTokenPayload = OidcIdTokenPayloadBase &
+	OidcIdTokenClaims &
+	OidcIdTokenCustomClaims;
 
 interface ParamBase {
 	clientId: string;
@@ -30,7 +36,7 @@ interface ParamBase {
 	accessToken: string;
 	privateKey: string;
 }
-type Param = ParamBase & OidcIdTokenClaims;
+type Param = ParamBase & OidcIdTokenClaims & OidcIdTokenCustomClaims;
 
 const signJWT = async (
 	payload: OidcIdTokenPayload,


### PR DESCRIPTION
id token の claims に roles を追加しました

一応背景としてk3sクラスタの認証で、OIDC経由でRoleを渡して権限を管理したいというのがあります

https://kubernetes.io/docs/reference/access-authn-authz/authentication/

> --oidc-groups-claim	JWT claim to use as the user's group. If the claim is present it must be an array of strings.
