### PR TITLE
refactor: API の型を schema から使う

### DIFF
--- a/workspaces/client/app/repository/auth.ts
+++ b/workspaces/client/app/repository/auth.ts
@@ -1,8 +1,8 @@
-import type { User } from "@idp/schema/entity/user";
+import type { GetMeResponse } from "@idp/schema/api/auth";
 import { client } from "~/utils/hono";
 
 export interface IAuthRepository {
-	me: () => Promise<User>;
+	me: () => Promise<GetMeResponse>;
 	me$$key(): unknown[];
 	ping(): Promise<void>;
 	ping$$key(): unknown[];

--- a/workspaces/client/app/routes/dashboard/admin/invites/internal/components/table.tsx
+++ b/workspaces/client/app/routes/dashboard/admin/invites/internal/components/table.tsx
@@ -1,5 +1,5 @@
+import type { AdminUserGetProvisionalUsersResponse } from "@idp/schema/api/admin/user";
 import { GRADE_BY_ID } from "@idp/schema/entity/grade";
-import type { User } from "@idp/schema/entity/user";
 import { useCallback } from "react";
 import { Check, X } from "react-feather";
 import { css } from "styled-system/css";
@@ -40,10 +40,7 @@ export const ProvisionalUsersTable = () => {
 const UserTableRow = ({
 	user,
 }: {
-	user: Omit<User, "certifications" | "oauthConnections"> & {
-		invitationTitle?: string;
-		invitationId?: string;
-	};
+	user: AdminUserGetProvisionalUsersResponse[number];
 }) => {
 	const { mutate: approveInvitation } = useApproveInvitation();
 	const { mutate: rejectInvitation } = useRejectInvitation();

--- a/workspaces/client/app/routes/dashboard/admin/users/internal/components/table.tsx
+++ b/workspaces/client/app/routes/dashboard/admin/users/internal/components/table.tsx
@@ -1,6 +1,6 @@
+import type { AdminUserGetUsersResponse } from "@idp/schema/api/admin/user";
 import { GRADE_BY_ID } from "@idp/schema/entity/grade";
 import { ROLE_IDS, type RoleId } from "@idp/schema/entity/role";
-import type { User } from "@idp/schema/entity/user";
 import { useCallback } from "react";
 import { Edit } from "react-feather";
 import { css } from "styled-system/css";
@@ -83,7 +83,7 @@ const ROLE_SLICE_LIMIT = 3;
 const UserTableRow = ({
 	user,
 }: {
-	user: Omit<User, "certifications" | "oauthConnections">;
+	user: AdminUserGetUsersResponse[number];
 }) => {
 	const { mutate: updateRole } = useUpdateRole(user.id);
 	const { mutate: confirmPayment } = useConfirmPayment(user.id);

--- a/workspaces/client/app/routes/dashboard/members/internal/hooks/use-members-filter.ts
+++ b/workspaces/client/app/routes/dashboard/members/internal/hooks/use-members-filter.ts
@@ -1,5 +1,5 @@
+import type { GetMembersResponse } from "@idp/schema/api/member";
 import { GradeId } from "@idp/schema/entity/grade";
-import type { Member } from "@idp/schema/entity/member";
 import { type Role, RoleId } from "@idp/schema/entity/role";
 import { useCallback, useMemo, useState } from "react";
 import * as v from "valibot";
@@ -16,9 +16,7 @@ const katakanaToHiragana = (str: string) => {
 	);
 };
 
-export function useMembersFilter(
-	members: Omit<Member, "certifications" | "oauthConnections">[],
-) {
+export function useMembersFilter(members: GetMembersResponse) {
 	const [filter, setFilter] = useState<Filter>({
 		keyword: "",
 		selectedGrades: [],

--- a/workspaces/schema/src/api/admin/user.ts
+++ b/workspaces/schema/src/api/admin/user.ts
@@ -1,4 +1,5 @@
 import * as v from "valibot";
+import { Invite } from "../../entity/invite";
 import { User } from "../../entity/user";
 
 export const AdminUserGetUsersResponse = v.array(
@@ -9,7 +10,13 @@ export type AdminUserGetUsersResponse = v.InferOutput<
 >;
 
 export const AdminUserGetProvisionalUsersResponse = v.array(
-	v.omit(User, ["certifications", "oauthConnections", "inviteIssuedAt"]),
+	v.intersect([
+		v.omit(User, ["certifications", "oauthConnections", "inviteIssuedAt"]),
+		v.object({
+			invitationTitle: v.optional(Invite.entries.title),
+			invitationId: v.optional(Invite.entries.id),
+		}),
+	]),
 );
 export type AdminUserGetProvisionalUsersResponse = v.InferOutput<
 	typeof AdminUserGetProvisionalUsersResponse

--- a/workspaces/schema/src/api/auth.ts
+++ b/workspaces/schema/src/api/auth.ts
@@ -1,0 +1,5 @@
+import type * as v from "valibot";
+import { User } from "../entity/user";
+
+export const GetMeResponse = User;
+export type GetMeResponse = v.InferOutput<typeof GetMeResponse>;

--- a/workspaces/schema/src/api/calendar/location.ts
+++ b/workspaces/schema/src/api/calendar/location.ts
@@ -24,3 +24,8 @@ export const CalendarLocationGetLocationsResponse = v.array(
 export type CalendarLocationGetLocationsResponse = v.InferOutput<
 	typeof CalendarLocationGetLocationsResponse
 >;
+
+export const CalendarLocationGetLocationByIdResponse = Location;
+export type CalendarLocationGetLocationByIdResponse = v.InferOutput<
+	typeof CalendarLocationGetLocationByIdResponse
+>;

--- a/workspaces/schema/src/api/member.ts
+++ b/workspaces/schema/src/api/member.ts
@@ -7,12 +7,12 @@ export const GetMembersResponse = v.array(
 );
 export type GetMembersResponse = v.InferOutput<typeof GetMembersResponse>;
 
-export const GetMembersContributionByUserDisplayIDResponse = Contributions;
-export type GetMembersContributionByUserDisplayIDResponse = v.InferOutput<
-	typeof GetMembersContributionByUserDisplayIDResponse
->;
-
 export const GetMembersProfileByUserDisplayIDResponse = Member;
 export type GetMembersProfileByUserDisplayIDResponse = v.InferOutput<
 	typeof GetMembersProfileByUserDisplayIDResponse
+>;
+
+export const GetMembersContributionByUserDisplayIDResponse = Contributions;
+export type GetMembersContributionByUserDisplayIDResponse = v.InferOutput<
+	typeof GetMembersContributionByUserDisplayIDResponse
 >;

--- a/workspaces/server/src/infrastructure/repository/cloudflare/user.ts
+++ b/workspaces/server/src/infrastructure/repository/cloudflare/user.ts
@@ -338,7 +338,6 @@ export class CloudflareUserRepository implements IUserRepository {
 			displayId: user.profile.displayId ?? undefined,
 			profileImageURL: user.profile.profileImageURL ?? undefined,
 			grade: v.is(GradeId, user.profile.grade) ? user.profile.grade : undefined,
-			bio: user.profile.bio ?? undefined,
 			roles: user.roles
 				.map((role) => role.roleId)
 				.filter((roleId) => v.is(RoleId, roleId))

--- a/workspaces/server/src/repository/user.ts
+++ b/workspaces/server/src/repository/user.ts
@@ -1,3 +1,4 @@
+import type { Invite } from "@idp/schema/entity/invite";
 import type { Member, PublicMember } from "@idp/schema/entity/member";
 import type { RoleId } from "@idp/schema/entity/role";
 import type { DashboardUser, User, UserProfile } from "@idp/schema/entity/user";
@@ -15,10 +16,13 @@ export type FetchMembersRes = Omit<
 	Member,
 	"certifications" | "oauthConnections"
 >[];
-export type FetchProvisionalUsersRes = Omit<
+export type FetchProvisionalUsersRes = (Omit<
 	User,
 	"certifications" | "oauthConnections" | "inviteIssuedAt"
->[];
+> & {
+	invitationTitle?: Invite["title"];
+	invitationId?: Invite["id"];
+})[];
 
 export interface IUserRepository {
 	createUser: (payload: CreateUserPayload) => Promise<string>;

--- a/workspaces/server/src/repository/user.ts
+++ b/workspaces/server/src/repository/user.ts
@@ -14,7 +14,7 @@ export type FetchApprovedUsersRes = Omit<
 >[];
 export type FetchMembersRes = Omit<
 	Member,
-	"certifications" | "oauthConnections"
+	"certifications" | "oauthConnections" | "bio"
 >[];
 export type FetchProvisionalUsersRes = (Omit<
 	User,

--- a/workspaces/server/src/routes/admin/dashboard.ts
+++ b/workspaces/server/src/routes/admin/dashboard.ts
@@ -1,3 +1,4 @@
+import type { GetDashboardInfoResponse } from "@idp/schema/api/admin/dashboard";
 import { factory } from "../../factory";
 import { memberOnlyMiddleware } from "../../middleware/auth";
 
@@ -6,7 +7,7 @@ const app = factory.createApp();
 const route = app.get("/info", memberOnlyMiddleware, async (c) => {
 	const { UserRepository } = c.var;
 	const users = await UserRepository.fetchAllUsers();
-	return c.json(users);
+	return c.json<GetDashboardInfoResponse>(users);
 });
 
 export { route as adminDashboardRoute };

--- a/workspaces/server/src/routes/admin/user.ts
+++ b/workspaces/server/src/routes/admin/user.ts
@@ -1,4 +1,8 @@
 import { vValidator } from "@hono/valibot-validator";
+import type {
+	AdminUserGetProvisionalUsersResponse,
+	AdminUserGetUsersResponse,
+} from "@idp/schema/api/admin/user";
 import { OAUTH_PROVIDER_IDS } from "@idp/schema/entity/oauth-internal/oauth-provider";
 import { RoleId } from "@idp/schema/entity/role";
 import * as v from "valibot";
@@ -19,7 +23,7 @@ const route = app
 	.get("/list", async (c) => {
 		const { UserRepository } = c.var;
 		const users = await UserRepository.fetchApprovedUsers();
-		return c.json(users);
+		return c.json<AdminUserGetUsersResponse>(users);
 	})
 	.put(
 		"/:userId/role",
@@ -45,7 +49,7 @@ const route = app
 	.get("/provisional", async (c) => {
 		const { UserRepository } = c.var;
 		const users = await UserRepository.fetchProvisionalUsers();
-		return c.json(users);
+		return c.json<AdminUserGetProvisionalUsersResponse>(users);
 	})
 	.post("/:userId/approve", async (c) => {
 		const userId = c.req.param("userId");

--- a/workspaces/server/src/routes/auth.ts
+++ b/workspaces/server/src/routes/auth.ts
@@ -1,3 +1,4 @@
+import type { GetMeResponse } from "@idp/schema/api/auth";
 import { deleteCookie } from "hono/cookie";
 import { COOKIE_NAME } from "../constants/cookie";
 import { factory } from "../factory";
@@ -24,7 +25,7 @@ const route = app
 		if (!res) {
 			return c.body(null, 404);
 		}
-		return c.json(res);
+		return c.json<GetMeResponse>(res);
 	})
 	.get("/ping", authMiddleware, async (c) => {
 		const payload = c.get("jwtPayload");

--- a/workspaces/server/src/routes/calendar/events.ts
+++ b/workspaces/server/src/routes/calendar/events.ts
@@ -1,6 +1,7 @@
 import { vValidator } from "@hono/valibot-validator";
 import {
 	CreateEventParams,
+	type GetEventsResponse,
 	UpdateEventParams,
 } from "@idp/schema/api/calendar/events";
 import { ROLE_IDS } from "@idp/schema/entity/role";
@@ -16,7 +17,7 @@ const route = app
 	.get("/", memberOnlyMiddleware, async (c) => {
 		const { CalendarRepository } = c.var;
 		const events = await CalendarRepository.getAllEvents();
-		return c.json(events);
+		return c.json<GetEventsResponse>(events);
 	})
 	.post(
 		"/",

--- a/workspaces/server/src/routes/calendar/location.ts
+++ b/workspaces/server/src/routes/calendar/location.ts
@@ -1,6 +1,8 @@
 import { vValidator } from "@hono/valibot-validator";
 import {
 	CalendarLocationCreateParams,
+	type CalendarLocationGetLocationByIdResponse,
+	type CalendarLocationGetLocationsResponse,
 	CalendarLocationUpdateParams,
 } from "@idp/schema/api/calendar/location";
 import { factory } from "../../factory";
@@ -15,7 +17,7 @@ const route = app
 	.get("/", memberOnlyMiddleware, async (c) => {
 		const { LocationRepository } = c.var;
 		const locations = await LocationRepository.getLocations();
-		return c.json(locations);
+		return c.json<CalendarLocationGetLocationsResponse>(locations);
 	})
 	.get("/:id", memberOnlyMiddleware, async (c) => {
 		const id = c.req.param("id");
@@ -27,7 +29,7 @@ const route = app
 		if (!location) {
 			return c.body(null, 404);
 		}
-		return c.json(location);
+		return c.json<CalendarLocationGetLocationByIdResponse>(location);
 	})
 	.post(
 		"/",

--- a/workspaces/server/src/routes/certification.ts
+++ b/workspaces/server/src/routes/certification.ts
@@ -4,6 +4,8 @@ import {
 	CertificationRequestParams,
 	CertificationReviewParams,
 	CertificationUpdateParams,
+	type GetAllCertificationsResponse,
+	type GetCertificationRequestsResponse,
 } from "@idp/schema/api/certification";
 import { factory } from "../factory";
 import { adminOnlyMiddleware, memberOnlyMiddleware } from "../middleware/auth";
@@ -14,7 +16,7 @@ const route = app
 	.get("/all", async (c) => {
 		const { CertificationRepository } = c.var;
 		const certifications = await CertificationRepository.getAllCertifications();
-		return c.json(certifications);
+		return c.json<GetAllCertificationsResponse>(certifications);
 	})
 	.post(
 		"/request",
@@ -38,7 +40,7 @@ const route = app
 		const { CertificationRepository } = c.var;
 		const requests =
 			await CertificationRepository.getAllCertificationRequests();
-		return c.json(requests);
+		return c.json<GetCertificationRequestsResponse>(requests);
 	})
 	.put(
 		"/review",

--- a/workspaces/server/src/routes/equipment.ts
+++ b/workspaces/server/src/routes/equipment.ts
@@ -1,5 +1,9 @@
 import { vValidator } from "@hono/valibot-validator";
-import { CreateOrUpdateEquipmentParams } from "@idp/schema/api/equipment";
+import {
+	CreateOrUpdateEquipmentParams,
+	type GetEquipmentByIdResponse,
+	type GetEquipmentsResponse,
+} from "@idp/schema/api/equipment";
 import { factory } from "../factory";
 import {
 	equipmentMutableMiddleware,
@@ -13,7 +17,7 @@ const route = app
 		const { EquipmentRepository } = c.var;
 
 		const equipments = await EquipmentRepository.getAllEquipments();
-		return c.json(equipments);
+		return c.json<GetEquipmentsResponse>(equipments);
 	})
 	.get("/:id", memberOnlyMiddleware, async (c) => {
 		const id = c.req.param("id");
@@ -27,7 +31,7 @@ const route = app
 			return c.body(null, 404);
 		}
 
-		return c.json(equipment);
+		return c.json<GetEquipmentByIdResponse>(equipment);
 	})
 	.post(
 		"/",

--- a/workspaces/server/src/routes/invite.ts
+++ b/workspaces/server/src/routes/invite.ts
@@ -1,5 +1,8 @@
 import { vValidator } from "@hono/valibot-validator";
-import { InviteCreateParams } from "@idp/schema/api/invite";
+import {
+	type GetInvitesResponse,
+	InviteCreateParams,
+} from "@idp/schema/api/invite";
 import { factory } from "../factory";
 import { adminOnlyMiddleware } from "../middleware/auth";
 import { noCacheMiddleware } from "../middleware/cache";
@@ -23,7 +26,7 @@ const protectedRoute = app
 	.get("/", async (c) => {
 		const { InviteRepository } = c.var;
 		const invites = await InviteRepository.getAllInvites();
-		return c.json(invites);
+		return c.json<GetInvitesResponse>(invites);
 	})
 	.post(
 		"/",

--- a/workspaces/server/src/routes/member.ts
+++ b/workspaces/server/src/routes/member.ts
@@ -1,3 +1,8 @@
+import type {
+	GetMembersContributionByUserDisplayIDResponse,
+	GetMembersProfileByUserDisplayIDResponse,
+	GetMembersResponse,
+} from "@idp/schema/api/member";
 import { OAUTH_PROVIDER_IDS } from "@idp/schema/entity/oauth-internal/oauth-provider";
 import { factory } from "../factory";
 import { memberOnlyMiddleware } from "../middleware/auth";
@@ -8,7 +13,7 @@ const route = app
 	.get("/list", memberOnlyMiddleware, async (c) => {
 		const { UserRepository } = c.var;
 		const members = await UserRepository.fetchMembers();
-		return c.json(members);
+		return c.json<GetMembersResponse>(members);
 	})
 	.get("/profile/:userDisplayId", memberOnlyMiddleware, async (c) => {
 		const userDisplayId = c.req.param("userDisplayId");
@@ -21,7 +26,7 @@ const route = app
 		if (!member) {
 			return c.body(null, 404);
 		}
-		return c.json(member);
+		return c.json<GetMembersProfileByUserDisplayIDResponse>(member);
 	})
 	.get("/contribution/:userDisplayId", memberOnlyMiddleware, async (c) => {
 		const userDisplayId = c.req.param("userDisplayId");
@@ -49,7 +54,7 @@ const route = app
 		);
 
 		if (cached) {
-			return c.json(cached);
+			return c.json<GetMembersContributionByUserDisplayIDResponse>(cached);
 		}
 
 		const contributions = await ContributionRepository.getContributions(
@@ -62,7 +67,7 @@ const route = app
 			ContributionCacheRepository.set(githubConn.name, contributions),
 		);
 
-		return c.json(contributions);
+		return c.json<GetMembersContributionByUserDisplayIDResponse>(contributions);
 	});
 
 export { route as memberRoute };

--- a/workspaces/server/src/routes/oauth/manage.ts
+++ b/workspaces/server/src/routes/oauth/manage.ts
@@ -1,5 +1,9 @@
 import { vValidator } from "@hono/valibot-validator";
-import { OAuthAppRegisterParams } from "@idp/schema/api/oauth/manage";
+import {
+	type OAuthAppGetClientByIdResponse,
+	type OAuthAppGetListResponse,
+	OAuthAppRegisterParams,
+} from "@idp/schema/api/oauth/manage";
 import { stream } from "hono/streaming";
 import * as v from "valibot";
 import { optimizeImage } from "wasm-image-optimization";
@@ -42,14 +46,16 @@ const secretDescriptionSchema = v.object({
 
 const route = app
 	.get("/list", authMiddleware, async (c) =>
-		c.json(await c.var.OAuthExternalRepository.getClients()),
+		c.json<OAuthAppGetListResponse>(
+			await c.var.OAuthExternalRepository.getClients(),
+		),
 	)
 	.get("/:clientId", authMiddleware, verifyOAuthClientMiddleware, async (c) => {
 		const client = c.get("oauthClientInfo");
 		if (!client) return c.text("Not found", 404);
 		const { secrets, ...rest } = client;
 
-		return c.json({
+		return c.json<OAuthAppGetClientByIdResponse>({
 			...rest,
 			secrets: await Promise.all(
 				secrets.map(async (secret) => ({

--- a/workspaces/server/src/routes/oauth/resources.ts
+++ b/workspaces/server/src/routes/oauth/resources.ts
@@ -1,6 +1,9 @@
 // OAuth の Resource Owner としての役割を果たすルーティング
 
-import type { AuthUserResponse } from "@idp/schema/api/oauth/resources";
+import type {
+	AuthUserResponse,
+	UserInfoResponse,
+} from "@idp/schema/api/oauth/resources";
 import type { OIDCUserInfo } from "@idp/schema/entity/oauth-external/oidc-userinfo";
 import {
 	SCOPE_IDS,
@@ -97,7 +100,7 @@ const route = app
 			}
 		}
 
-		return c.json<OIDCUserInfo>(userInfo);
+		return c.json<UserInfoResponse>(userInfo);
 	});
 
 export { route as oauthResourcesRoute };

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -1,5 +1,8 @@
 import { vValidator } from "@hono/valibot-validator";
-import { UserProfileUpdateParams } from "@idp/schema/api/user";
+import {
+	type UserGetContributionsResponse,
+	UserProfileUpdateParams,
+} from "@idp/schema/api/user";
 import {
 	OAUTH_PROVIDER_IDS,
 	OAuthProviderId,
@@ -143,7 +146,7 @@ const route = app
 		);
 
 		if (cached) {
-			return c.json(cached, 200);
+			return c.json<UserGetContributionsResponse>(cached, 200);
 		}
 
 		const contributions = await ContributionRepository.getContributions(
@@ -156,7 +159,7 @@ const route = app
 			ContributionCacheRepository.set(githubConn.name, contributions),
 		);
 
-		return c.json(contributions, 200);
+		return c.json<UserGetContributionsResponse>(contributions, 200);
 	})
 	.put(
 		"/profile-image",


### PR DESCRIPTION
## About

- server 側の `c.json` で型パラメータ指定しておらず、 API が実際に返す型と schema 側でずれが生じ得たのを是正
- client 側で `Omit` とかで少し回りくどい感じがしたので schema に寄せた

### やりながら思った改善点 (今後の TODO; 要相談)

- 型の import、 entity / api の使い分けが割と曖昧
- repository と schema 共通部分多すぎるがこのままでいい？
- 実際には使ってないデータを返してる部分を削減したい？ (けっこうたいへんそう)
  - ex: `fetchProvisionalUsers` では lastLoginAt, roles, bio, ... を使わないのに取得してる