### PR TITLE
feat(oauth): persist consent grants

### DIFF
--- a/workspaces/client/app/components/feature/user/setting/hooks/use-oauth-grants.ts
+++ b/workspaces/client/app/components/feature/user/setting/hooks/use-oauth-grants.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+
+export const useOAuthGrants = () => {
+	const { userRepository } = useRepository();
+
+	return useQuery({
+		queryKey: userRepository.getOAuthGrants$$key(),
+		queryFn: () => userRepository.getOAuthGrants(),
+		initialData: [],
+	});
+};

--- a/workspaces/client/app/components/feature/user/setting/hooks/use-revoke-oauth-grant.ts
+++ b/workspaces/client/app/components/feature/user/setting/hooks/use-revoke-oauth-grant.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRepository } from "~/hooks/use-repository";
+import { useToast } from "~/hooks/use-toast";
+
+export const useRevokeOAuthGrant = () => {
+	const queryClient = useQueryClient();
+	const { userRepository } = useRepository();
+	const { pushToast } = useToast();
+
+	return useMutation({
+		mutationFn: (clientId: string) => userRepository.revokeOAuthGrant(clientId),
+		onSuccess: () => {
+			pushToast({
+				type: "success",
+				title: "承認済みアプリを解除しました",
+				description: "必要になった場合は、次回利用時に再度承認してください。",
+			});
+			queryClient.invalidateQueries({
+				queryKey: userRepository.getOAuthGrants$$key(),
+			});
+		},
+		onError: () => {
+			pushToast({
+				type: "error",
+				title: "承認済みアプリを解除できませんでした",
+				description: "もう一度お試しください",
+			});
+		},
+	});
+};

--- a/workspaces/client/app/components/feature/user/setting/partial-form/oauth.tsx
+++ b/workspaces/client/app/components/feature/user/setting/partial-form/oauth.tsx
@@ -14,8 +14,11 @@ import { AnchorLike } from "~/components/ui/anchor-like";
 import { Details } from "~/components/ui/details";
 import { Table } from "~/components/ui/table";
 import { useAuth } from "~/hooks/use-auth";
+import { formatDateTime } from "~/utils/date";
 import { env } from "~/utils/env";
 import { useDeleteOAuthConnection } from "../hooks/use-delete-oauth-connection";
+import { useOAuthGrants } from "../hooks/use-oauth-grants";
+import { useRevokeOAuthGrant } from "../hooks/use-revoke-oauth-grant";
 
 const OAuthConnRow = ({
 	providerId,
@@ -76,6 +79,86 @@ const OAuthConnRow = ({
 	);
 };
 
+const AuthorizedApps = () => {
+	const { data: grants, isLoading } = useOAuthGrants();
+	const { mutate } = useRevokeOAuthGrant();
+
+	const handleRevoke = useCallback(
+		async (clientId: string, appName: string) => {
+			const res = await ConfirmDialog.call({
+				title: `${appName} の承認を解除`,
+				children: <DeleteConfirmation />,
+				danger: true,
+			});
+			if (res.type === "dismiss") return;
+			mutate(clientId);
+		},
+		[mutate],
+	);
+
+	return (
+		<div
+			className={css({
+				width: "100%",
+				display: "flex",
+				flexDirection: "column",
+				gap: 3,
+			})}
+		>
+			<h2
+				className={css({
+					fontSize: "xl",
+					fontWeight: "bold",
+					color: "gray.600",
+					width: "100%",
+				})}
+			>
+				承認済みアプリ
+			</h2>
+			<p
+				className={css({ color: "gray.600", textAlign: "left", width: "100%" })}
+			>
+				Maximum IdP の情報へのアクセスを許可した外部アプリです。
+				解除すると、次回利用時に再度承認が必要になります。
+			</p>
+			<Table.Root loading={isLoading}>
+				<Table.Tr>
+					<Table.Th>アプリ</Table.Th>
+					<Table.Th>許可した情報</Table.Th>
+					<Table.Th>最終更新</Table.Th>
+					<Table.Th>解除</Table.Th>
+				</Table.Tr>
+				{grants.length === 0 && (
+					<Table.Tr>
+						<Table.Td>承認済みアプリはありません</Table.Td>
+						<Table.Td />
+						<Table.Td />
+						<Table.Td />
+					</Table.Tr>
+				)}
+				{grants.map((grant) => (
+					<Table.Tr key={grant.client.id}>
+						<Table.Td>{grant.client.name}</Table.Td>
+						<Table.Td>
+							{grant.scopes.map((scope) => scope.name).join(", ")}
+						</Table.Td>
+						<Table.Td>{formatDateTime(grant.updatedAt)}</Table.Td>
+						<Table.Td>
+							<button
+								onClick={() => handleRevoke(grant.client.id, grant.client.name)}
+								type="button"
+								className={css({ cursor: "pointer" })}
+							>
+								<AnchorLike>承認を解除する</AnchorLike>
+							</button>
+						</Table.Td>
+					</Table.Tr>
+				))}
+			</Table.Root>
+		</div>
+	);
+};
+
 export const UserSettingFormOAuth = () => {
 	const { user, isLoading } = useAuth();
 
@@ -104,6 +187,8 @@ export const UserSettingFormOAuth = () => {
 					/>
 				))}
 			</Table.Root>
+
+			<AuthorizedApps />
 
 			<Details summary="なぜ連携解除できないサービスがあるの？">
 				これらのサービスが提供する機能やデータが、 Maximum

--- a/workspaces/client/app/repository/user.ts
+++ b/workspaces/client/app/repository/user.ts
@@ -4,6 +4,7 @@ import type {
 } from "@idp/schema/api/admin/user";
 import type {
 	UserGetContributionsResponse,
+	UserOAuthGrantsResponse,
 	UserProfileUpdateParams,
 } from "@idp/schema/api/user";
 import type { RoleId } from "@idp/schema/entity/role";
@@ -26,6 +27,9 @@ export interface IUserRepository {
 	rejectInvitation: (userId: string) => Promise<void>;
 	confirmPayment: (userId: string) => Promise<void>;
 	deleteOAuthConnection: (providerId: number) => Promise<void>;
+	getOAuthGrants: () => Promise<UserOAuthGrantsResponse>;
+	getOAuthGrants$$key: () => unknown[];
+	revokeOAuthGrant: (clientId: string) => Promise<void>;
 }
 
 export class UserRepositoryImpl implements IUserRepository {
@@ -238,6 +242,33 @@ export class UserRepositoryImpl implements IUserRepository {
 		});
 		if (!res.ok) {
 			throw new Error("Failed to delete OAuth connection");
+		}
+	}
+
+	async getOAuthGrants() {
+		const res = await client.user["oauth-grants"].$get();
+		if (!res.ok) {
+			throw new Error("Failed to fetch OAuth grants");
+		}
+		const data = await res.json();
+		return data.map((grant) => ({
+			...grant,
+			updatedAt: new Date(grant.updatedAt),
+		}));
+	}
+
+	getOAuthGrants$$key() {
+		return ["oauth-grants"];
+	}
+
+	async revokeOAuthGrant(clientId: string) {
+		const res = await client.user["oauth-grants"][":clientId"].$delete({
+			param: {
+				clientId,
+			},
+		});
+		if (!res.ok) {
+			throw new Error("Failed to revoke OAuth grant");
 		}
 	}
 }

--- a/workspaces/schema/src/api/user.ts
+++ b/workspaces/schema/src/api/user.ts
@@ -3,6 +3,8 @@ import { Contributions } from "../entity/contribution";
 import { DEPARTMENT_BY_ID, toDepartmentId } from "../entity/department";
 import { FACULTY_IDS, toFacultyId } from "../entity/faculty";
 import { isOutsideGrade, toGradeId } from "../entity/grade";
+import { Client } from "../entity/oauth-external/client";
+import { Scope } from "../entity/oauth-external/scope";
 import { RoleId } from "../entity/role";
 import { UserProfile } from "../entity/user";
 
@@ -132,3 +134,14 @@ export const UserRoleUpdateParams = v.object({
 	roleIds: v.array(RoleId),
 });
 export type UserRoleUpdateParams = v.InferOutput<typeof UserRoleUpdateParams>;
+
+export const UserOAuthGrantsResponse = v.array(
+	v.object({
+		client: v.pick(Client, ["id", "name", "description", "logoUrl"]),
+		scopes: v.array(Scope),
+		updatedAt: v.date(),
+	}),
+);
+export type UserOAuthGrantsResponse = v.InferOutput<
+	typeof UserOAuthGrantsResponse
+>;

--- a/workspaces/server/drizzle/0035_curved_korg.sql
+++ b/workspaces/server/drizzle/0035_curved_korg.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `oauth_grants` (
+	`user_id` text NOT NULL,
+	`client_id` text NOT NULL,
+	`scope_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`revoked_at` integer,
+	PRIMARY KEY(`user_id`, `client_id`, `scope_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`client_id`) REFERENCES `oauth_clients`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `oauth_grants_user_client_idx` ON `oauth_grants` (`user_id`,`client_id`);

--- a/workspaces/server/drizzle/meta/0035_snapshot.json
+++ b/workspaces/server/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1308 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "6725f558-a523-4a39-a64b-586da97ee8ba",
+	"prevId": "d84ad0b1-53ec-4b45-93fd-1c1c7110d034",
+	"tables": {
+		"calendar_events": {
+			"name": "calendar_events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"start_at": {
+					"name": "start_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"end_at": {
+					"name": "end_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location_id": {
+					"name": "location_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_idx": {
+					"name": "user_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				},
+				"start_at_idx": {
+					"name": "start_at_idx",
+					"columns": ["start_at"],
+					"isUnique": false
+				},
+				"end_at_idx": {
+					"name": "end_at_idx",
+					"columns": ["end_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"calendar_events_user_id_users_id_fk": {
+					"name": "calendar_events_user_id_users_id_fk",
+					"tableFrom": "calendar_events",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"calendar_events_location_id_locations_id_fk": {
+					"name": "calendar_events_location_id_locations_id_fk",
+					"tableFrom": "calendar_events",
+					"tableTo": "locations",
+					"columnsFrom": ["location_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"certifications": {
+			"name": "certifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				}
+			},
+			"indexes": {
+				"certifications_title_unique": {
+					"name": "certifications_title_unique",
+					"columns": ["title"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"equipments": {
+			"name": "equipments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"owner_id": {
+					"name": "owner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"equipments_owner_id_users_id_fk": {
+					"name": "equipments_owner_id_users_id_fk",
+					"tableFrom": "equipments",
+					"tableTo": "users",
+					"columnsFrom": ["owner_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"invite_roles": {
+			"name": "invite_roles",
+			"columns": {
+				"invite_id": {
+					"name": "invite_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"invite_roles_invite_id_invites_id_fk": {
+					"name": "invite_roles_invite_id_invites_id_fk",
+					"tableFrom": "invite_roles",
+					"tableTo": "invites",
+					"columnsFrom": ["invite_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"invite_roles_invite_id_role_id_pk": {
+					"columns": ["invite_id", "role_id"],
+					"name": "invite_roles_invite_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"invites": {
+			"name": "invites",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"remaining_use": {
+					"name": "remaining_use",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"issued_by": {
+					"name": "issued_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"invites_issued_by_users_id_fk": {
+					"name": "invites_issued_by_users_id_fk",
+					"tableFrom": "invites",
+					"tableTo": "users",
+					"columnsFrom": ["issued_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"locations": {
+			"name": "locations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"social_links": {
+			"name": "social_links",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"social_links_user_idx": {
+					"name": "social_links_user_idx",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"social_links_user_id_users_id_fk": {
+					"name": "social_links_user_id_users_id_fk",
+					"tableFrom": "social_links",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_certifications": {
+			"name": "user_certifications",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"certification_id": {
+					"name": "certification_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"certified_in": {
+					"name": "certified_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_approved": {
+					"name": "is_approved",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"user_certifiedat_idx": {
+					"name": "user_certifiedat_idx",
+					"columns": ["user_id", "certified_in"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_certifications_user_id_users_id_fk": {
+					"name": "user_certifications_user_id_users_id_fk",
+					"tableFrom": "user_certifications",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"user_certifications_certification_id_certifications_id_fk": {
+					"name": "user_certifications_certification_id_certifications_id_fk",
+					"tableFrom": "user_certifications",
+					"tableTo": "certifications",
+					"columnsFrom": ["certification_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_certifications_user_id_certification_id_pk": {
+					"columns": ["user_id", "certification_id"],
+					"name": "user_certifications_user_id_certification_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_profiles": {
+			"name": "user_profiles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"real_name": {
+					"name": "real_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"real_name_kana": {
+					"name": "real_name_kana",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_id": {
+					"name": "display_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"profile_image_url": {
+					"name": "profile_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"academic_email": {
+					"name": "academic_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"student_id": {
+					"name": "student_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty": {
+					"name": "faculty",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"department": {
+					"name": "department",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"laboratory": {
+					"name": "laboratory",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"graduate_school": {
+					"name": "graduate_school",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"specialization": {
+					"name": "specialization",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"bio": {
+					"name": "bio",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"grade_idx": {
+					"name": "grade_idx",
+					"columns": ["grade"],
+					"isUnique": false
+				},
+				"display_id_unique": {
+					"name": "display_id_unique",
+					"columns": ["display_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_profiles_user_id_users_id_fk": {
+					"name": "user_profiles_user_id_users_id_fk",
+					"tableFrom": "user_profiles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_roles": {
+			"name": "user_roles",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"columns": ["user_id", "role_id"],
+					"name": "user_roles_user_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"initialized_at": {
+					"name": "initialized_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"invitation_id": {
+					"name": "invitation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_payment_confirmed_at": {
+					"name": "last_payment_confirmed_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"users_invitation_id_invites_id_fk": {
+					"name": "users_invitation_id_invites_id_fk",
+					"tableFrom": "users",
+					"tableTo": "invites",
+					"columnsFrom": ["invitation_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_client_callbacks": {
+			"name": "oauth_client_callbacks",
+			"columns": {
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"callback_url": {
+					"name": "callback_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_callbacks_client_id_oauth_clients_id_fk": {
+					"name": "oauth_client_callbacks_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_client_callbacks",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_client_callbacks_client_id_callback_url_pk": {
+					"columns": ["client_id", "callback_url"],
+					"name": "oauth_client_callbacks_client_id_callback_url_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_client_managers": {
+			"name": "oauth_client_managers",
+			"columns": {
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_managers_client_id_oauth_clients_id_fk": {
+					"name": "oauth_client_managers_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_client_managers",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"oauth_client_managers_user_id_users_id_fk": {
+					"name": "oauth_client_managers_user_id_users_id_fk",
+					"tableFrom": "oauth_client_managers",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_client_managers_client_id_user_id_pk": {
+					"columns": ["client_id", "user_id"],
+					"name": "oauth_client_managers_client_id_user_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_client_scopes": {
+			"name": "oauth_client_scopes",
+			"columns": {
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_scopes_client_id_oauth_clients_id_fk": {
+					"name": "oauth_client_scopes_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_client_scopes",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_client_scopes_client_id_scope_id_pk": {
+					"columns": ["client_id", "scope_id"],
+					"name": "oauth_client_scopes_client_id_scope_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_client_secrets": {
+			"name": "oauth_client_secrets",
+			"columns": {
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secret": {
+					"name": "secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"secret_hash": {
+					"name": "secret_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"secret_suffix": {
+					"name": "secret_suffix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"issued_by": {
+					"name": "issued_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"issued_at": {
+					"name": "issued_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_secrets_client_id_oauth_clients_id_fk": {
+					"name": "oauth_client_secrets_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_client_secrets",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"oauth_client_secrets_issued_by_users_id_fk": {
+					"name": "oauth_client_secrets_issued_by_users_id_fk",
+					"tableFrom": "oauth_client_secrets",
+					"tableTo": "users",
+					"columnsFrom": ["issued_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_client_secrets_client_id_secret_pk": {
+					"columns": ["client_id", "secret"],
+					"name": "oauth_client_secrets_client_id_secret_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_clients": {
+			"name": "oauth_clients",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"logo_url": {
+					"name": "logo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"owner_id": {
+					"name": "owner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_clients_owner_id_users_id_fk": {
+					"name": "oauth_clients_owner_id_users_id_fk",
+					"tableFrom": "oauth_clients",
+					"tableTo": "users",
+					"columnsFrom": ["owner_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_grants": {
+			"name": "oauth_grants",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"oauth_grants_user_client_idx": {
+					"name": "oauth_grants_user_client_idx",
+					"columns": ["user_id", "client_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"oauth_grants_user_id_users_id_fk": {
+					"name": "oauth_grants_user_id_users_id_fk",
+					"tableFrom": "oauth_grants",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"oauth_grants_client_id_oauth_clients_id_fk": {
+					"name": "oauth_grants_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_grants",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_grants_user_id_client_id_scope_id_pk": {
+					"columns": ["user_id", "client_id", "scope_id"],
+					"name": "oauth_grants_user_id_client_id_scope_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_token_scopes": {
+			"name": "oauth_token_scopes",
+			"columns": {
+				"token_id": {
+					"name": "token_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_token_scopes_token_id_oauth_tokens_id_fk": {
+					"name": "oauth_token_scopes_token_id_oauth_tokens_id_fk",
+					"tableFrom": "oauth_token_scopes",
+					"tableTo": "oauth_tokens",
+					"columnsFrom": ["token_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"oauth_token_scopes_token_id_scope_id_pk": {
+					"columns": ["token_id", "scope_id"],
+					"name": "oauth_token_scopes_token_id_scope_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_tokens": {
+			"name": "oauth_tokens",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code_expires_at": {
+					"name": "code_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code_used": {
+					"name": "code_used",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"redirect_uri": {
+					"name": "redirect_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code_challenge": {
+					"name": "code_challenge",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code_challenge_method": {
+					"name": "code_challenge_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"oidc_nonce": {
+					"name": "oidc_nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"oidc_auth_time": {
+					"name": "oidc_auth_time",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"oauth_tokens_code_unique": {
+					"name": "oauth_tokens_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				},
+				"oauth_tokens_access_token_unique": {
+					"name": "oauth_tokens_access_token_unique",
+					"columns": ["access_token"],
+					"isUnique": true
+				},
+				"oauth_tokens_access_token_expires_at_idx": {
+					"name": "oauth_tokens_access_token_expires_at_idx",
+					"columns": ["access_token_expires_at"],
+					"isUnique": false
+				},
+				"oauth_tokens_code_expires_at_idx": {
+					"name": "oauth_tokens_code_expires_at_idx",
+					"columns": ["code_expires_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"oauth_tokens_client_id_oauth_clients_id_fk": {
+					"name": "oauth_tokens_client_id_oauth_clients_id_fk",
+					"tableFrom": "oauth_tokens",
+					"tableTo": "oauth_clients",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"oauth_tokens_user_id_users_id_fk": {
+					"name": "oauth_tokens_user_id_users_id_fk",
+					"tableFrom": "oauth_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"oauth_connections": {
+			"name": "oauth_connections",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_user_id": {
+					"name": "provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"profile_image_url": {
+					"name": "profile_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"oauth_connections_user_id_provider_id_pk": {
+					"columns": ["user_id", "provider_id"],
+					"name": "oauth_connections_user_id_provider_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/workspaces/server/drizzle/meta/_journal.json
+++ b/workspaces/server/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
 			"when": 1779170124000,
 			"tag": "0034_oauth_pkce_secret_hash",
 			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "6",
+			"when": 1781961790493,
+			"tag": "0035_curved_korg",
+			"breakpoints": true
 		}
 	]
 }

--- a/workspaces/server/src/db/schema/oauth/external.ts
+++ b/workspaces/server/src/db/schema/oauth/external.ts
@@ -73,6 +73,26 @@ export const oauthClientScopes = sqliteTable(
 	(table) => [primaryKey({ columns: [table.clientId, table.scopeId] })],
 );
 
+export const oauthGrants = sqliteTable(
+	"oauth_grants",
+	{
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id),
+		clientId: text("client_id")
+			.notNull()
+			.references(() => oauthClients.id),
+		scopeId: int("scope_id", { mode: "number" }).notNull(),
+		createdAt: int("created_at", { mode: "timestamp_ms" }).notNull(),
+		updatedAt: int("updated_at", { mode: "timestamp_ms" }).notNull(),
+		revokedAt: int("revoked_at", { mode: "timestamp_ms" }),
+	},
+	(table) => [
+		primaryKey({ columns: [table.userId, table.clientId, table.scopeId] }),
+		index("oauth_grants_user_client_idx").on(table.userId, table.clientId),
+	],
+);
+
 export const oauthTokens = sqliteTable(
 	"oauth_tokens",
 	{
@@ -130,6 +150,7 @@ export const oauthClientsRelations = relations(
 		secrets: many(oauthClientSecrets),
 		callbacks: many(oauthClientCallbacks),
 		scopes: many(oauthClientScopes),
+		grants: many(oauthGrants),
 	}),
 );
 
@@ -180,6 +201,17 @@ export const oauthClientScopesRelations = relations(
 		}),
 	}),
 );
+
+export const oauthGrantsRelations = relations(oauthGrants, ({ one }) => ({
+	client: one(oauthClients, {
+		fields: [oauthGrants.clientId],
+		references: [oauthClients.id],
+	}),
+	user: one(users, {
+		fields: [oauthGrants.userId],
+		references: [users.id],
+	}),
+}));
 
 export const oauthTokensRelations = relations(oauthTokens, ({ one, many }) => ({
 	client: one(oauthClients, {

--- a/workspaces/server/src/infrastructure/repository/cloudflare/oauth-external.ts
+++ b/workspaces/server/src/infrastructure/repository/cloudflare/oauth-external.ts
@@ -6,7 +6,7 @@ import {
 	ScopeId,
 } from "@idp/schema/entity/oauth-external/scope";
 import { ROLE_BY_ID, RoleId } from "@idp/schema/entity/role";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import * as v from "valibot";
 import * as schema from "../../../db/schema";
@@ -518,6 +518,125 @@ export class CloudflareOAuthExternalRepository
 				socialLinks: undefined,
 			},
 		};
+	}
+
+	async getGrantedScopes(userId: string, clientId: string) {
+		const res = await this.client.query.oauthGrants.findMany({
+			where: (grant, { eq, and, isNull }) =>
+				and(
+					eq(grant.userId, userId),
+					eq(grant.clientId, clientId),
+					isNull(grant.revokedAt),
+				),
+		});
+
+		return res
+			.map((grant) => grant.scopeId)
+			.filter((scopeId) => v.is(ScopeId, scopeId))
+			.map((scopeId) => SCOPES_BY_ID[scopeId]);
+	}
+
+	async upsertGrantScopes(userId: string, clientId: string, scopes: Scope[]) {
+		if (scopes.length === 0) return;
+
+		const now = new Date();
+		const res = await this.client
+			.insert(schema.oauthGrants)
+			.values(
+				scopes.map((scope) => ({
+					userId,
+					clientId,
+					scopeId: scope.id,
+					createdAt: now,
+					updatedAt: now,
+					revokedAt: null,
+				})),
+			)
+			.onConflictDoUpdate({
+				target: [
+					schema.oauthGrants.userId,
+					schema.oauthGrants.clientId,
+					schema.oauthGrants.scopeId,
+				],
+				set: {
+					updatedAt: now,
+					revokedAt: null,
+				},
+			});
+
+		if (!res.success) throw new Error("Failed to upsert oauth grant");
+	}
+
+	async getUserGrantedClients(userId: string) {
+		const grants = await this.client.query.oauthGrants.findMany({
+			where: (grant, { eq, and, isNull }) =>
+				and(eq(grant.userId, userId), isNull(grant.revokedAt)),
+			with: {
+				client: true,
+			},
+		});
+
+		const grouped = new Map<
+			string,
+			{
+				client: {
+					id: string;
+					name: string;
+					description: string | null;
+					logoUrl: string | null;
+				};
+				scopeIds: Set<ScopeId>;
+				updatedAt: Date;
+			}
+		>();
+
+		for (const grant of grants) {
+			if (!v.is(ScopeId, grant.scopeId)) continue;
+
+			const existing = grouped.get(grant.clientId);
+			if (existing) {
+				existing.scopeIds.add(grant.scopeId);
+				if (existing.updatedAt < grant.updatedAt) {
+					existing.updatedAt = grant.updatedAt;
+				}
+				continue;
+			}
+
+			grouped.set(grant.clientId, {
+				client: {
+					id: grant.client.id,
+					name: grant.client.name,
+					description: grant.client.description,
+					logoUrl: grant.client.logoUrl,
+				},
+				scopeIds: new Set([grant.scopeId]),
+				updatedAt: grant.updatedAt,
+			});
+		}
+
+		return [...grouped.values()]
+			.map((grant) => ({
+				client: grant.client,
+				scopes: [...grant.scopeIds].map((scopeId) => SCOPES_BY_ID[scopeId]),
+				updatedAt: grant.updatedAt,
+			}))
+			.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+	}
+
+	async revokeClientGrant(userId: string, clientId: string) {
+		const now = new Date();
+		const res = await this.client
+			.update(schema.oauthGrants)
+			.set({ updatedAt: now, revokedAt: now })
+			.where(
+				and(
+					eq(schema.oauthGrants.userId, userId),
+					eq(schema.oauthGrants.clientId, clientId),
+					isNull(schema.oauthGrants.revokedAt),
+				),
+			);
+
+		if (!res.success) throw new Error("Failed to revoke oauth grant");
 	}
 
 	async deleteExpiredAccessTokens() {

--- a/workspaces/server/src/mocks/repository/oauth-external.ts
+++ b/workspaces/server/src/mocks/repository/oauth-external.ts
@@ -24,6 +24,10 @@ export const createMockOAuthExternalRepository =
 			deleteTokenById: vi.fn(),
 			consumeCode: vi.fn(),
 			getTokenByAccessToken: vi.fn(),
+			getGrantedScopes: vi.fn(),
+			upsertGrantScopes: vi.fn(),
+			getUserGrantedClients: vi.fn(),
+			revokeClientGrant: vi.fn(),
 
 			// cron
 			deleteExpiredAccessTokens: vi.fn(),

--- a/workspaces/server/src/repository/oauth-external.ts
+++ b/workspaces/server/src/repository/oauth-external.ts
@@ -37,6 +37,12 @@ type GetTokenByATRes = ClientToken & {
 	user: Pick<User, "id"> & { profile: Partial<UserProfile>; roles: Role[] };
 };
 
+type GetUserGrantedClientRes = {
+	client: Pick<Client, "id" | "name" | "description" | "logoUrl">;
+	scopes: Scope[];
+	updatedAt: Date;
+};
+
 export type IOAuthExternalRepository = {
 	// common
 	getClientById: (clientId: string) => Promise<GetClientByIdRes | undefined>;
@@ -90,6 +96,14 @@ export type IOAuthExternalRepository = {
 	getTokenByAccessToken: (
 		accessToken: string,
 	) => Promise<GetTokenByATRes | undefined>;
+	getGrantedScopes: (userId: string, clientId: string) => Promise<Scope[]>;
+	upsertGrantScopes: (
+		userId: string,
+		clientId: string,
+		scopes: Scope[],
+	) => Promise<void>;
+	getUserGrantedClients: (userId: string) => Promise<GetUserGrantedClientRes[]>;
+	revokeClientGrant: (userId: string, clientId: string) => Promise<void>;
 
 	// cron
 	deleteExpiredAccessTokens: () => Promise<void>;

--- a/workspaces/server/src/routes/oauth/authorization-success.ts
+++ b/workspaces/server/src/routes/oauth/authorization-success.ts
@@ -1,0 +1,142 @@
+import type { PkceCodeChallengeMethod } from "@idp/schema/entity/oauth-external/pkce";
+import { SCOPE_IDS } from "@idp/schema/entity/oauth-external/scope";
+import type { Context } from "hono";
+import type { HonoEnv } from "../../factory";
+import { ACCESS_TOKEN_EXPIRES_IN } from "../../utils/oauth/constant";
+import { binaryToBase64 } from "../../utils/oauth/convert-bin-base64";
+import { generateIdToken } from "../../utils/oauth/oidc-logic";
+
+export const OAUTH_ERROR_URI =
+	"https://github.com/saitamau-maximum/id/wiki/oauth-errors#authorization-endpoint";
+
+type AuthorizationSuccessParams = {
+	clientId: string;
+	userId: string;
+	responseType: string;
+	responseMode?: string;
+	redirectUri?: string;
+	scope?: string;
+	state?: string;
+	oidcNonce?: string;
+	oidcAuthTime?: number;
+	codeChallenge?: string;
+	codeChallengeMethod?: PkceCodeChallengeMethod;
+	saveGrant: boolean;
+};
+
+export const createAuthorizationSuccessRedirect = async (
+	c: Context<HonoEnv>,
+	{
+		clientId,
+		userId,
+		responseType,
+		responseMode,
+		redirectUri,
+		scope,
+		state,
+		oidcNonce,
+		oidcAuthTime,
+		codeChallenge,
+		codeChallengeMethod,
+		saveGrant,
+	}: AuthorizationSuccessParams,
+) => {
+	const client = await c.var.OAuthExternalRepository.getClientById(clientId);
+	if (!client) throw new Error("client not found");
+
+	let redirectTo: URL;
+	if (redirectUri) {
+		redirectTo = new URL(redirectUri);
+	} else {
+		if (client.callbackUrls.length !== 1) {
+			throw new Error("client callback not found");
+		}
+		redirectTo = new URL(client.callbackUrls[0]);
+	}
+
+	const requestedScopes = new Set(scope ? scope.split(" ") : []);
+	const scopes = client.scopes.filter((data) => {
+		if (requestedScopes.size === 0) return true;
+		return requestedScopes.has(data.name);
+	});
+
+	if (saveGrant) {
+		await c.var.OAuthExternalRepository.upsertGrantScopes(
+			userId,
+			clientId,
+			scopes,
+		);
+	}
+
+	const code = binaryToBase64(crypto.getRandomValues(new Uint8Array(30)));
+	const accessToken = binaryToBase64(
+		crypto.getRandomValues(new Uint8Array(39)),
+	);
+
+	await c.var.OAuthExternalRepository.createAccessToken(
+		clientId,
+		userId,
+		code,
+		redirectUri,
+		accessToken,
+		scopes,
+		codeChallenge,
+		codeChallengeMethod,
+		oidcNonce,
+		oidcAuthTime,
+	);
+
+	if (state) redirectTo.searchParams.append("state", state);
+
+	if (responseType === "code") {
+		redirectTo.searchParams.append("code", code);
+		return c.redirect(redirectTo.href, 302);
+	}
+
+	const res = new URLSearchParams();
+	if (responseType === "id_token token" || responseType === "token id_token") {
+		res.append("access_token", accessToken);
+		res.append("token_type", "Bearer");
+		res.append("expires_in", ACCESS_TOKEN_EXPIRES_IN.toString());
+	}
+
+	const userInfo = await c.var.UserRepository.fetchUserProfileById(userId);
+
+	const idToken = await generateIdToken({
+		clientId,
+		userId,
+		exp: Math.floor(Date.now() / 1000) + ACCESS_TOKEN_EXPIRES_IN,
+		authTime: oidcAuthTime,
+		nonce: oidcNonce,
+		accessToken,
+		privateKey: c.env.PRIVKEY_FOR_OAUTH,
+		...(scopes.find((s) => s.id === SCOPE_IDS.PROFILE)
+			? {
+					name: userInfo.realName,
+					nickname: userInfo.displayName,
+					preferred_username: userInfo.displayId,
+					picture: userInfo.profileImageURL,
+				}
+			: {}),
+		...(scopes.find((s) => s.id === SCOPE_IDS.EMAIL)
+			? {
+					email: userInfo.email,
+				}
+			: {}),
+		...(scopes.find((s) => s.id === SCOPE_IDS.READ_ROLES)
+			? {
+					roles: userInfo.roles.map((r) => r.slug),
+				}
+			: {}),
+	});
+
+	res.append("id_token", idToken);
+	if (state) res.append("state", state);
+
+	if (responseMode === "query") {
+		redirectTo.search = res.toString();
+	} else {
+		redirectTo.hash = res.toString();
+	}
+	return c.redirect(redirectTo.href, 302);
+};

--- a/workspaces/server/src/routes/oauth/authorize.tsx
+++ b/workspaces/server/src/routes/oauth/authorize.tsx
@@ -27,6 +27,10 @@ import { generateAuthToken } from "../../utils/oauth/auth-token";
 import { importKey } from "../../utils/oauth/key";
 import { _Authorize } from "./_templates/authorize";
 import { layoutRendererMiddleware } from "./_templates/layout";
+import {
+	createAuthorizationSuccessRedirect,
+	OAUTH_ERROR_URI,
+} from "./authorization-success";
 
 // 仕様はここ参照: https://github.com/saitamau-maximum/auth/issues/27
 
@@ -340,12 +344,12 @@ const route = app
 			};
 
 			if (isOidc && prompt === "none") {
-				// 現状では同意済みフラグを持っていないので、 consent interaction を強制することになる
-				// TODO: none でもうまくできるようにする
-				return errorRedirect(
-					"interaction_required",
-					"End-User must consent to use OpenID Connect",
-				);
+				if (!loggedInAt) {
+					return errorRedirect(
+						"login_required",
+						"End-User must be logged in to use prompt=none",
+					);
+				}
 			}
 			if (isOidc && prompt === "login") {
 				if (loggedInAt && loggedInAt + 20 > nowMs / 1000) {
@@ -382,6 +386,7 @@ const route = app
 				redirectTo,
 				scope,
 				state,
+				prompt,
 				oidcNonce: nonce,
 				oidcAuthTime: loggedInAt,
 				codeChallenge,
@@ -399,6 +404,7 @@ const route = app
 				redirectTo,
 				scope,
 				state,
+				prompt,
 				oidcNonce,
 				oidcAuthTime,
 				codeChallenge,
@@ -433,6 +439,51 @@ const route = app
 			// 初期登録まだ
 			if (!userInfo.initializedAt) {
 				return c.text("Forbidden: user not initialized", 403);
+			}
+
+			const grantedScopes =
+				await c.var.OAuthExternalRepository.getGrantedScopes(userId, clientId);
+			const grantedScopeNames = new Set(
+				grantedScopes.map((scope) => scope.name),
+			);
+			const hasAllRequestedScopes = clientInfo.scopes.every((scope) =>
+				grantedScopeNames.has(scope.name),
+			);
+
+			if (prompt === "none" && !hasAllRequestedScopes) {
+				const callback = new URL(redirectTo);
+				callback.searchParams.append("error", "consent_required");
+				callback.searchParams.append(
+					"error_description",
+					"End-User consent is required",
+				);
+				callback.searchParams.append("error_uri", OAUTH_ERROR_URI);
+				if (state) callback.searchParams.append("state", state);
+				return c.redirect(callback.toString(), 302);
+			}
+
+			if (prompt !== "consent" && hasAllRequestedScopes) {
+				const callback = new URL(redirectTo);
+				return await createAuthorizationSuccessRedirect(c, {
+					clientId,
+					userId,
+					responseType,
+					responseMode,
+					redirectUri,
+					scope,
+					state,
+					oidcNonce,
+					oidcAuthTime,
+					codeChallenge,
+					codeChallengeMethod,
+					saveGrant: false,
+				}).catch((e: Error) => {
+					callback.searchParams.append("error", "server_error");
+					callback.searchParams.append("error_description", e.message);
+					callback.searchParams.append("error_uri", OAUTH_ERROR_URI);
+					if (state) callback.searchParams.append("state", state);
+					return c.redirect(callback.href, 302);
+				});
 			}
 
 			return c.render(

--- a/workspaces/server/src/routes/oauth/callback.ts
+++ b/workspaces/server/src/routes/oauth/callback.ts
@@ -1,18 +1,15 @@
 import { vValidator } from "@hono/valibot-validator";
 import { OAuthCallbackRequestParams } from "@idp/schema/api/oauth/callback";
-import { SCOPE_IDS } from "@idp/schema/entity/oauth-external/scope";
 import { factory } from "../../factory";
 import { cookieAuthMiddleware } from "../../middleware/auth";
 import { validateAuthToken } from "../../utils/oauth/auth-token";
-import { ACCESS_TOKEN_EXPIRES_IN } from "../../utils/oauth/constant";
-import { binaryToBase64 } from "../../utils/oauth/convert-bin-base64";
 import { derivePublicKey, importKey, jwkToKey } from "../../utils/oauth/key";
-import { generateIdToken } from "../../utils/oauth/oidc-logic";
+import {
+	createAuthorizationSuccessRedirect,
+	OAUTH_ERROR_URI,
+} from "./authorization-success";
 
 // 仕様はここ参照: https://github.com/saitamau-maximum/auth/issues/29
-
-const OAUTH_ERROR_URI =
-	"https://github.com/saitamau-maximum/id/wiki/oauth-errors#authorization-endpoint";
 
 const app = factory.createApp();
 
@@ -108,105 +105,25 @@ const route = app
 				return c.redirect(redirectTo.href, 302);
 			}
 
-			// scope 取得
-			const requestedScopes = new Set(scope ? scope.split(" ") : []);
-			const scopes = client.scopes.filter((data) => {
-				// scope リクエストしてない場合は requestedScopes = [] なので、全部 true として付与
-				if (requestedScopes.size === 0) return true;
-				// そうでない場合はリクエストされた scope だけを付与
-				return requestedScopes.has(data.name);
-			});
-
-			// code (240bit = 8bit * 30) を生成
-			const code = binaryToBase64(crypto.getRandomValues(new Uint8Array(30)));
-
-			// access token (312bit = 8bit * 39) を生成
-			const accessToken = binaryToBase64(
-				crypto.getRandomValues(new Uint8Array(39)),
-			);
-
-			// DB に格納して返す
-			return await c.var.OAuthExternalRepository.createAccessToken(
-				client_id,
+			return await createAuthorizationSuccessRedirect(c, {
+				clientId: client_id,
 				userId,
-				code,
-				redirect_uri,
-				accessToken,
-				scopes,
-				code_challenge,
-				code_challenge_method,
-				oidc_nonce,
-				oidc_auth_time,
-			)
-				.then(async () => {
-					if (response_type === "code") {
-						redirectTo.searchParams.append("code", code);
-						return c.redirect(redirectTo.href, 302);
-					}
-
-					// OpenID Connect Implicit Flow
-					const res = new URLSearchParams();
-					if (
-						// 順不同なので
-						response_type === "id_token token" ||
-						response_type === "token id_token"
-					) {
-						// Access Token も返す
-						res.append("access_token", accessToken);
-						res.append("token_type", "Bearer");
-						res.append("expires_in", ACCESS_TOKEN_EXPIRES_IN.toString());
-					}
-
-					const userInfo =
-						await c.var.UserRepository.fetchUserProfileById(userId);
-
-					const id_token = await generateIdToken({
-						clientId: client_id,
-						userId,
-						exp: Math.floor(Date.now() / 1000) + ACCESS_TOKEN_EXPIRES_IN,
-						authTime: oidc_auth_time,
-						nonce: oidc_nonce,
-						accessToken,
-						privateKey: c.env.PRIVKEY_FOR_OAUTH,
-						// 必要最低限の情報は含める
-						...(scopes.find((s) => s.id === SCOPE_IDS.PROFILE)
-							? {
-									name: userInfo.realName,
-									nickname: userInfo.displayName,
-									preferred_username: userInfo.displayId,
-									picture: userInfo.profileImageURL,
-								}
-							: {}),
-						...(scopes.find((s) => s.id === SCOPE_IDS.EMAIL)
-							? {
-									email: userInfo.email,
-								}
-							: {}),
-						// Custom Claims
-						...(scopes.find((s) => s.id === SCOPE_IDS.READ_ROLES)
-							? {
-									roles: userInfo.roles.map((r) => r.slug),
-								}
-							: {}),
-					});
-
-					res.append("id_token", id_token);
-					if (state) res.append("state", state);
-
-					if (response_mode === "query") {
-						redirectTo.search = res.toString();
-					} else {
-						// default: fragment (Section 3.2.2.5)
-						redirectTo.hash = res.toString();
-					}
-					return c.redirect(redirectTo.href, 302);
-				})
-				.catch((e: Error) => {
-					redirectTo.searchParams.append("error", "server_error");
-					redirectTo.searchParams.append("error_description", e.message);
-					redirectTo.searchParams.append("error_uri", OAUTH_ERROR_URI);
-					return c.redirect(redirectTo.href, 302);
-				});
+				responseType: response_type,
+				responseMode: response_mode,
+				redirectUri: redirect_uri,
+				scope,
+				state,
+				oidcNonce: oidc_nonce,
+				oidcAuthTime: oidc_auth_time,
+				codeChallenge: code_challenge,
+				codeChallengeMethod: code_challenge_method,
+				saveGrant: true,
+			}).catch((e: Error) => {
+				redirectTo.searchParams.append("error", "server_error");
+				redirectTo.searchParams.append("error_description", e.message);
+				redirectTo.searchParams.append("error_uri", OAUTH_ERROR_URI);
+				return c.redirect(redirectTo.href, 302);
+			});
 		},
 	)
 	.all(async (c) => {

--- a/workspaces/server/src/routes/user.ts
+++ b/workspaces/server/src/routes/user.ts
@@ -1,6 +1,7 @@
 import { vValidator } from "@hono/valibot-validator";
 import {
 	type UserGetContributionsResponse,
+	type UserOAuthGrantsResponse,
 	UserProfileUpdateParams,
 	UserRoleUpdateParams,
 } from "@idp/schema/api/user";
@@ -219,6 +220,19 @@ const route = app
 		}
 
 		await OAuthInternalRepository.deleteOAuthConnection(userId, providerId);
+		return c.body(null, 204);
+	})
+	.get("/oauth-grants", memberOnlyMiddleware, async (c) => {
+		const { userId } = c.get("jwtPayload");
+		const grants =
+			await c.var.OAuthExternalRepository.getUserGrantedClients(userId);
+		return c.json<UserOAuthGrantsResponse>(grants, 200);
+	})
+	.delete("/oauth-grants/:clientId", memberOnlyMiddleware, async (c) => {
+		const { userId } = c.get("jwtPayload");
+		const clientId = c.req.param("clientId");
+
+		await c.var.OAuthExternalRepository.revokeClientGrant(userId, clientId);
 		return c.body(null, 204);
 	})
 	.get("/profile-image/:userId", async (c) => {

--- a/workspaces/server/src/tests/auto-role-delete.test.ts
+++ b/workspaces/server/src/tests/auto-role-delete.test.ts
@@ -9,6 +9,7 @@ import { CloudflareUserRepository } from "../infrastructure/repository/cloudflar
 const clearDatabase = async () => {
 	await env.DB.exec(`
     PRAGMA foreign_keys = OFF;
+    DELETE FROM oauth_grants;
     DELETE FROM oauth_token_scopes;
     DELETE FROM oauth_tokens;
     DELETE FROM oauth_client_scopes;

--- a/workspaces/server/src/tests/oauth2.test.ts
+++ b/workspaces/server/src/tests/oauth2.test.ts
@@ -380,6 +380,188 @@ describe("OAuth 2.0 spec", () => {
 				expect(callbackUrl.searchParams.has("code")).toBe(true);
 			});
 
+			it("skips consent after the same scopes were granted", async () => {
+				const { cookie, clientId } = await setup(
+					[SCOPE_IDS.READ_BASIC_INFO],
+					[DEFAULT_REDIRECT_URI],
+				);
+				const params = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+				});
+
+				const res1 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res1.status).toBe(200);
+				await authorize(await res1.text(), cookie);
+
+				const res2 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res2.status).toBe(302);
+				const redirectUrl = res2.headers.get("Location");
+				assert.isNotNull(redirectUrl);
+				expect(new URL(redirectUrl).searchParams.has("code")).toBe(true);
+			});
+
+			it("requires consent when requested scopes increase", async () => {
+				const { cookie, clientId, userId } = await setup(
+					[SCOPE_IDS.READ_BASIC_INFO, SCOPE_IDS.READ_ROLES],
+					[DEFAULT_REDIRECT_URI],
+				);
+				const firstParams = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+					scope: "read:basic_info",
+				});
+
+				const res1 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${firstParams.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res1.status).toBe(200);
+				await authorize(await res1.text(), cookie);
+
+				const expandedParams = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+					scope: "read:basic_info read:roles",
+				});
+				const res2 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${expandedParams.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res2.status).toBe(200);
+				await authorize(await res2.text(), cookie);
+
+				const grantedScopes = await oauthExternalRepository.getGrantedScopes(
+					userId,
+					clientId,
+				);
+				expect(grantedScopes.map((scope) => scope.name).sort()).toEqual([
+					"read:basic_info",
+					"read:roles",
+				]);
+			});
+
+			it("shows consent when prompt=consent even if scopes were granted", async () => {
+				const { cookie, clientId } = await setup(
+					[SCOPE_IDS.READ_BASIC_INFO],
+					[DEFAULT_REDIRECT_URI],
+				);
+				const params = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+				});
+
+				const res1 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res1.status).toBe(200);
+				await authorize(await res1.text(), cookie);
+
+				params.set("prompt", "consent");
+				const res2 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res2.status).toBe(200);
+			});
+
+			it("handles prompt=none with granted and missing consent", async () => {
+				const { cookie, clientId } = await setup(
+					[SCOPE_IDS.OPENID],
+					[DEFAULT_REDIRECT_URI],
+				);
+				const params = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+					scope: "openid",
+				});
+
+				const missingConsentParams = new URLSearchParams(params);
+				missingConsentParams.set("prompt", "none");
+				const missingConsentRes = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${missingConsentParams.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(missingConsentRes.status).toBe(302);
+				const missingConsentRedirect =
+					missingConsentRes.headers.get("Location");
+				assert.isNotNull(missingConsentRedirect);
+				expect(new URL(missingConsentRedirect).searchParams.get("error")).toBe(
+					"consent_required",
+				);
+
+				const loginRequiredRes = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${missingConsentParams.toString()}`,
+				);
+				expect(loginRequiredRes.status).toBe(302);
+				const loginRequiredRedirect = loginRequiredRes.headers.get("Location");
+				assert.isNotNull(loginRequiredRedirect);
+				expect(new URL(loginRequiredRedirect).searchParams.get("error")).toBe(
+					"login_required",
+				);
+
+				const res1 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res1.status).toBe(200);
+				await authorize(await res1.text(), cookie);
+
+				const grantedRes = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${missingConsentParams.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(grantedRes.status).toBe(302);
+				const grantedRedirect = grantedRes.headers.get("Location");
+				assert.isNotNull(grantedRedirect);
+				const grantedUrl = new URL(grantedRedirect);
+				expect(grantedUrl.searchParams.has("code")).toBe(true);
+				expect(grantedUrl.searchParams.has("error")).toBe(false);
+			});
+
+			it("requires consent again after the client grant is revoked", async () => {
+				const { cookie, clientId } = await setup(
+					[SCOPE_IDS.READ_BASIC_INFO],
+					[DEFAULT_REDIRECT_URI],
+				);
+				const params = new URLSearchParams({
+					response_type: "code",
+					client_id: clientId,
+				});
+
+				const res1 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res1.status).toBe(200);
+				await authorize(await res1.text(), cookie);
+
+				const skippedRes = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(skippedRes.status).toBe(302);
+
+				const revokeRes = await app.request(`/user/oauth-grants/${clientId}`, {
+					method: "DELETE",
+					headers: { Cookie: cookie },
+				});
+				expect(revokeRes.status).toBe(204);
+
+				const res2 = await app.request(
+					`${AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+					{ headers: { Cookie: cookie } },
+				);
+				expect(res2.status).toBe(200);
+			});
+
 			it("expires code after 10 minutes [RECOMMENDED]", async () => {
 				// A maximum authorization code lifetime of 10 minutes is RECOMMENDED.
 				const { userId, clientId, code } = await doAuthFlow();

--- a/workspaces/server/src/tests/oauth2/common.ts
+++ b/workspaces/server/src/tests/oauth2/common.ts
@@ -14,6 +14,7 @@ import type { HonoEnv } from "../../factory";
 import { CloudflareOAuthExternalRepository } from "../../infrastructure/repository/cloudflare/oauth-external";
 import { CloudflareUserRepository } from "../../infrastructure/repository/cloudflare/user";
 import { oauthRoute } from "../../routes/oauth";
+import { userRoute } from "../../routes/user";
 import { wellKnownRoute } from "../../routes/well-known";
 import { binaryToBase64Url } from "../../utils/oauth/convert-bin-base64";
 import { exportKey, generateKeyPair } from "../../utils/oauth/key";
@@ -57,6 +58,7 @@ export const createOAuthTestContext = async () => {
 	app
 		.use(repositoryInjector)
 		.route("/oauth", oauthRoute)
+		.route("/user", userRoute)
 		.route("/.well-known", wellKnownRoute);
 
 	const setup = async (scopes?: ScopeId[], callbackUrls?: string[]) => {


### PR DESCRIPTION
## どういう変更か

OAuth/OIDC の consent grant を永続化し、既承認の OAuth client / scope に対する authorization request では承認画面をスキップするようにします。

主な変更点は以下です。

- `oauth_grants` テーブルを追加し、`user_id`, `client_id`, `scope_id` 単位で承認済み scope を保存する
- authorization callback でユーザーが承認した scope を grant として保存する
- `/oauth/authorize` で要求 scope がすべて承認済みの場合、承認画面を表示せず認可コード発行へ進む
- `prompt=consent` では既承認でも承認画面を表示する
- `prompt=none` では未ログイン時に `login_required`、未承認 scope がある場合に `consent_required` を返す
- ユーザー設定の OAuth 連携タブに承認済みアプリ一覧と revoke 操作を追加する

## なぜ変更するのか

現在はログイン済みかつ同じ OAuth client / scope への request であっても、毎回承認画面が表示されます。

Grafana など Maximum IdP を OIDC Provider として利用するサービスでは、SSO のたびに追加操作が発生し、一般的な IdP と比べて UX が重くなっています。

また、既存 consent を判定できないため、`prompt=none` に対して UI なしで成功できるケースと、ログインや consent が必要なケースを区別できていませんでした。

この変更により、初回のみ明示的な承認を求め、以降は保存済み grant に基づいて authorization flow を継続できるようにします。

## 実装判断

### scope 単位で grant を保存する

client 単位の boolean ではなく、`user_id`, `client_id`, `scope_id` の組で保存します。

これにより、既存 client が追加 scope を要求した場合に、未承認 scope を検出して再度 consent を要求できます。また、client の登録 scope が変更された場合でも、保存済み grant と現在の request scope を比較して判断できます。

### revoke はアプリ単位にする

ユーザー設定画面では、scope 単位ではなく client 単位で grant を revoke します。

ユーザー操作としては「このアプリへの承認を解除する」が自然であり、scope ごとの細かい revoke UI は今回の課題に対して過剰なためです。DB は scope 単位で保持しているため、将来的に scope 単位 revoke が必要になっても拡張できます。

### authorization success 処理を共通化する

承認画面経由の flow と、grant 済みで承認画面をスキップする flow は、最終的に同じ認可コード / token 発行処理を行います。

そのため、redirect URI の組み立て、認可コード生成、access token 生成、OIDC implicit response 生成を共通関数へ切り出し、両経路の挙動差分を grant 保存の有無だけに限定しています。